### PR TITLE
API: Whitelist sortBy field using an EnumType

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ query Members {
         ID
         FirstName
         Email
-        Groups(sortBy:[{field: "Title", direction:DESC}]) {
+        Groups(sortBy:[{field:Title, direction:DESC}]) {
           edges {
             node {
               ID

--- a/src/Pagination/Connection.php
+++ b/src/Pagination/Connection.php
@@ -21,7 +21,7 @@ use InvalidArgumentException;
  * and return a list of edges.
  *
  * <code>
- *  friends(limit:2,offset:2,sortBy:[{field:"Name",direction:ASC}]) {
+ *  friends(limit:2,offset:2,sortBy:[{field:Name,direction:ASC}]) {
  *     edges {
  *       node {
  *         name
@@ -229,19 +229,26 @@ class Connection extends Object
             $existing = [];
         }
 
-        return array_merge($existing, [
+        $args = array_merge($existing, [
             'limit' => [
                 'type' => Type::int(),
             ],
             'offset' => [
                 'type' => Type::int()
-            ],
-            'sortBy' => [
-                'type' => Type::listOf(
-                    Injector::inst()->get(SortInputType::class)->toType()
-                )
             ]
         ]);
+
+        if($fields = $this->getSortableFields()) {
+            $args['sortBy'] = [
+                'type' => Type::listOf(
+                    Injector::inst()->create(SortInputType::class, $this->connectionName)
+                        ->setSortableFields($fields)
+                        ->toType()
+                )
+            ];
+        }
+
+        return $args;
     }
 
     /**

--- a/src/Pagination/SortDirectionType.php
+++ b/src/Pagination/SortDirectionType.php
@@ -7,8 +7,8 @@ use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\EnumType;
 use GraphQL\Type\Definition\ObjectType;
 
-class SortDirectionType extends Object {
-
+class SortDirectionType extends Object
+{
     /**
      * @var ObjectType
      */
@@ -17,7 +17,8 @@ class SortDirectionType extends Object {
     /**
      * @return ObjectType
      */
-    public function toType() {
+    public function toType()
+    {
         if(!$this->type) {
             $this->type = new EnumType([
                 'name' => 'SortDirection',

--- a/src/Pagination/SortInputType.php
+++ b/src/Pagination/SortInputType.php
@@ -6,25 +6,72 @@ use SilverStripe\Core\Object;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\InputObjectType;
 use SilverStripe\Core\Injector\Injector;
+use GraphQL\Type\Definition\EnumType;
 
-class SortInputType extends Object {
-
+class SortInputType extends Object
+{
     /**
      * @var InputObjectType
      */
     private $type;
 
     /**
+     * @var string
+     */
+    private $inputName;
+
+
+    /**
+     * @var array
+     */
+    protected $sortableFields = [];
+
+    /**
+     *
+     */
+    public function __construct($name)
+    {
+        $this->inputName = $name;
+    }
+
+    /**
+     * @param array $sortableFields
+     *
+     * @return $this
+     */
+    public function setSortableFields($sortableFields)
+    {
+        $this->sortableFields = $sortableFields;
+
+        return $this;
+    }
+
+    /**
      * @return ObjectType
      */
-    public function toType() {
+    public function toType()
+    {
+        $values = [];
+
+        foreach($this->sortableFields as $field) {
+            $values[$field] = [
+                'value' => $field
+            ];
+        }
+
+        $sortableField  =  new EnumType([
+            'name' => $this->inputName . 'SortFieldType',
+            'description' => 'Field name to sort by.',
+            'values' => $values
+        ]);
+
         if(!$this->type) {
             $this->type = new InputObjectType([
-                'name' => 'sortBy',
+                'name' => $this->inputName .'InputObjectType',
                 'description' => 'Define the sorting',
                 'fields' => [
                     'field' => [
-                        'type' => Type::nonNull(Type::string()),
+                        'type' => Type::nonNull($sortableField),
                         'description' => 'Sort field name.'
                     ],
                     'direction' => [

--- a/src/Pagination/SortInputType.php
+++ b/src/Pagination/SortInputType.php
@@ -22,7 +22,8 @@ class SortInputType extends Object
 
 
     /**
-     * @var array
+     * @var array Keyed by field argument name, values as DataObject column names.
+     * Does not support in-memory sorting for composite values (getters).
      */
     protected $sortableFields = [];
 
@@ -53,9 +54,9 @@ class SortInputType extends Object
     {
         $values = [];
 
-        foreach($this->sortableFields as $field) {
-            $values[$field] = [
-                'value' => $field
+        foreach($this->sortableFields as $fieldAlias => $fieldName) {
+            $values[$fieldAlias] = [
+                'value' => $fieldAlias
             ];
         }
 

--- a/src/Pagination/SortInputType.php
+++ b/src/Pagination/SortInputType.php
@@ -61,14 +61,14 @@ class SortInputType extends Object
         }
 
         $sortableField  =  new EnumType([
-            'name' => $this->inputName . 'SortFieldType',
+            'name' => ucfirst($this->inputName) . 'SortFieldType',
             'description' => 'Field name to sort by.',
             'values' => $values
         ]);
 
         if(!$this->type) {
             $this->type = new InputObjectType([
-                'name' => $this->inputName .'InputObjectType',
+                'name' => ucfirst($this->inputName) .'SortInputType',
                 'description' => 'Define the sorting',
                 'fields' => [
                     'field' => [


### PR DESCRIPTION
`sortBy` now only accepts the whitelisted field names. Marking as an API change since queries will need to change from quoted to unquoted strings.