### PR TITLE
API Apply draft to default graphql route

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -3,7 +3,10 @@ Name: graphqlroutes
 ---
 SilverStripe\Control\Director:
   rules:
-    'graphql': 'SilverStripe\GraphQL\Controller'
+    # Default admin route stage is draft
+    graphql:
+      Controller: 'SilverStripe\GraphQL\Controller'
+      Stage: Stage
 ---
 only:
   environment: 'dev'

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -7,6 +7,7 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Control\Director;
+use SilverStripe\ORM\Versioning\Versioned;
 use Exception;
 
 /**
@@ -21,6 +22,10 @@ class Controller extends BaseController
 
     public function index(HTTPRequest $request)
     {
+        $stage = $request->param('Stage');
+        if ($stage && in_array($stage, [Versioned::DRAFT, Versioned::LIVE])) {
+            Versioned::set_stage($stage);
+        }
         $isJson = (
             $request->getHeader('Content-Type') === 'application/json'
             || $request->getHeader('content-type') === 'application/json'


### PR DESCRIPTION
Does not fix, but is related to https://github.com/silverstripe/silverstripe-graphql/issues/30.

A better solution is to allow stage to be configurable per request, but at least this sets a good default reading stage.