### PR TITLE
Check route info array in dev/graphiql

### DIFF
--- a/src/GraphiQLController.php
+++ b/src/GraphiQLController.php
@@ -29,7 +29,8 @@ class GraphiQLController extends BaseController
         $route = null;
 
         foreach ($routes as $pattern => $controllerInfo) {
-            if ($controllerInfo == Controller::class || is_subclass_of($controllerInfo, Controller::class)) {
+            $routeClass = (is_string($controllerInfo)) ? $controllerInfo : $controllerInfo['Controller'];
+            if ($routeClass == Controller::class || is_subclass_of($routeClass, Controller::class)) {
                 $route = $pattern;
                 break;
             }


### PR DESCRIPTION
Route definitions have more than one allowed format,
either a plain string, or an object with a 'Controller' key.
We've changed the /graphql endpoint to the latter in order
to set the 'Stage' as well, which broke dev/graphiql.

/cc @unclecheese