### PR TITLE
Connection->setArgs() callable support

### DIFF
--- a/src/Pagination/Connection.php
+++ b/src/Pagination/Connection.php
@@ -127,7 +127,7 @@ class Connection implements OperationResolver
     }
 
     /**
-     * @param array
+     * @param array|Callable
      *
      * @return $this
      */
@@ -219,7 +219,7 @@ class Connection implements OperationResolver
      */
     public function args()
     {
-        $existing = $this->args;
+        $existing = is_callable($this->args) ? call_user_func($this->args) : $this->args;
 
         if (!is_array($existing)) {
             $existing = [];

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -228,4 +228,36 @@ class ConnectionTest extends SapphireTest
         $built = $type->toType();
         $this->assertInstanceOf(InputObjectField::class, $built->getField('field'));
     }
+
+    public function testArgsAsArray()
+    {
+        $connection = Connection::create('testFakeConnection')
+            ->setConnectionType(function () {
+                return $this->manager->getType('TypeCreatorFake');
+            })
+            ->setArgs([
+                'arg1' => [
+                    'type' => Type::int()
+                ]
+            ]);
+
+        $this->assertArrayHasKey('arg1', $connection->args());
+    }
+
+    public function testArgsAsCallable()
+    {
+        $connection = Connection::create('testFakeConnection')
+            ->setConnectionType(function () {
+                return $this->manager->getType('TypeCreatorFake');
+            })
+            ->setArgs(function () {
+                return [
+                    'arg1' => [
+                        'type' => Type::int()
+                    ]
+                ];
+            });
+
+        $this->assertArrayHasKey('arg1', $connection->args());
+    }
 }


### PR DESCRIPTION
Args can reference input types, which in turn need a reference in the $manager instance,
same as setConnectionType().