### PR TITLE
API Add support for BasicAuth to be used for native permission checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,72 @@ This tool is available in **dev mode only**. It can be accessed at
 
 <img src="https://github.com/graphql/graphiql/raw/master/resources/graphiql.png">
 
+## Authentication
+
+Some SilverStripe resources have permission requirements to perform CRUD operations
+on, for example the `Member` object in the previous examples.
+
+If you are logged into the CMS and performing a request from the same session then
+the same Member session is used to authenticate GraphQL requests, however if you
+are performing requests from an anonymous/external application you may need to
+authenticate before you can complete a request.
+
+Please note that when implementing GraphQL resources it is the developer's
+responsibility to ensure that permission checks are implemented wherever
+resources are accessed.
+
+### Basic Authentication
+
+Silverstripe has built in support for [HTTP basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication).
+It can be configured for GraphQL implementation with YAML configuration (see below).
+This is kept separate from the SilverStripe CMS authenticator because GraphQL needs
+to use the successfully authenticated member for CMS permission filtering, whereas
+the global `BasicAuth` does not log the member in or use it for model security.
+
+#### YAML configuration
+
+You will need to define the class under `SilverStripe\GraphQL.authenticators`.
+You can optionally provide a `priority` number if you want to control which
+Authenticator is used when multiple are defined (higher priority returns first).
+
+Here's an example for implementing HTTP basic authentication:
+
+```yaml
+SilverStripe\GraphQL:
+  authenticators:
+    - class: SilverStripe\GraphQL\Auth\BasicAuthAuthenticator
+      priority: 10
+```
+
+#### In GraphiQL
+
+If you want to add basic authentication support to your GraphQL requests you can
+do so by adding a custom `Authorization` HTTP header to your GraphiQL requests.
+
+If you are using the [GraphiQL macOS app](https://github.com/skevy/graphiql-app)
+this can be done from "Edit HTTP Headers". The `/dev/graphiql` implementation
+does not support custom HTTP headers at this point.
+
+Your custom header should follow the following format:
+
+```
+# Key: Value
+Authorization: Basic aGVsbG86d29ybGQ=
+```
+
+`Basic` is followed by a [base64 encoded](https://en.wikipedia.org/wiki/Base64)
+combination of your username, colon and password. The above example is `hello:world`.
+
+**Note:** Authentication credentials are transferred in plain text when using HTTP
+basic authenticaiton. We strongly recommend using TLS for non-development use.
+
+Example:
+
+```shell
+php -r 'echo base64_encode("hello:world");'
+# aGVsbG86d29ybGQ=
+```
+
 ## TODO
 
  * Permission checks

--- a/examples/_config/config.yml
+++ b/examples/_config/config.yml
@@ -7,3 +7,7 @@ SilverStripe\GraphQL:
       readMembers: 'MyProject\GraphQL\ReadMembersQueryCreator'
     mutations:
       createMember: 'MyProject\GraphQL\CreateMemberMutationCreator'
+  # Enforce HTTP basic authentication for GraphQL requests
+  authenticators:
+    - class: SilverStripe\GraphQL\Auth\BasicAuthAuthenticator
+      priority: 10

--- a/src/Auth/AuthenticatorInterface.php
+++ b/src/Auth/AuthenticatorInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SilverStripe\GraphQL\Auth;
+
+use SilverStripe\Control\HTTPRequest;
+
+/**
+ * An AuthenticatorInterface is responsible for authenticating against a SilverStripe CMS Member from
+ * the given request data.
+ *
+ * It should return the authenticated Member if successful so that GraphQL can
+ * use it in place of the Member from the session for permission checks such as DataObject::canView.
+ *
+ * @package silverstripe-graphql
+ */
+interface AuthenticatorInterface
+{
+    /**
+     * Given the current request, authenticate the request for non-session authorization (outside the CMS).
+     *
+     * The Member returned from this method will be provided to the Manager for use in the OperationResolver context
+     * in place of the current CMS member.
+     *
+     * Authenticators can be given a priority. In this case, the authenticator with the highest priority will be
+     * returned first. If not provided, it will default to a low number.
+     *
+     * An example for configuring the BasicAuthAuthenticator:
+     *
+     * <code>
+     * SilverStripe\GraphQL:
+     *   authenticators:
+     *     - class: SilverStripe\GraphQL\Auth\BasicAuthAuthenticator
+     *       priority: 10
+     * </code>
+     *
+     * @param  HTTPRequest $request The current HTTP request
+     * @return Member               If authentication is successful
+     * @throws ValidationException  If authentication fails
+     */
+    public function authenticate(HTTPRequest $request);
+}

--- a/src/Auth/BasicAuthAuthenticator.php
+++ b/src/Auth/BasicAuthAuthenticator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SilverStripe\GraphQL\Auth;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Security\BasicAuth;
+
+/**
+ * An authenticator using SilverStripe's BasicAuth
+ *
+ * @package silverstripe-graphql
+ */
+class BasicAuthAuthenticator implements AuthenticatorInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function authenticate(HTTPRequest $request)
+    {
+        return BasicAuth::requireLogin('Restricted resource');
+    }
+}

--- a/src/Auth/Handler.php
+++ b/src/Auth/Handler.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace SilverStripe\GraphQL\Auth;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse_Exception;
+use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Security\Member;
+
+/**
+ * The authentication Handler is responsible for handling authentication requirements and providing a Member
+ * to the Manager if required, so it can be used in request contexts.
+ *
+ * @package silverstripe-graphql
+ */
+class Handler
+{
+    /**
+     * If required, enforce authentication for non-session authenticated requests. The Member returned from the
+     * authentication method will returned for use in the OperationResolver context.
+     *
+     * Authenticators are defined in configuration. @see AuthenticatorInterface::authenticate.
+     *
+     * @param  HTTPRequest $request
+     * @return Member|false           If authentication was successful the Member is returned. False if no
+     *                                authenticators are configured.
+     * @throws HTTPResponse_Exception If authentication is attempted and fails
+     */
+    public function requireAuthentication(HTTPRequest $request)
+    {
+        $authenticator = $this->getAuthenticator();
+        if (!$authenticator) {
+            return false;
+        }
+
+        $member = $authenticator->authenticate($request);
+        if ($member instanceof Member) {
+            return $member;
+        }
+        // Note: The authenticator class itself may also throw an exception
+        throw new HTTPResponse_Exception('Authentication failed.', 401);
+    }
+
+    /**
+     * Returns the first configured authenticator by highest priority, or false if none are configured
+     *
+     * @return AuthenticatorInterface|false
+     */
+    public function getAuthenticator()
+    {
+        $authenticators = Config::inst()->get('SilverStripe\GraphQL', 'authenticators');
+        if (empty($authenticators)) {
+            return false;
+        }
+
+        $this->prioritiseAuthenticators($authenticators);
+
+        $authenticator = false;
+        foreach ($authenticators as $authenticatorConfig) {
+            if (!ClassInfo::classImplements($authenticatorConfig['class'], AuthenticatorInterface::class)) {
+                throw new ValidationException(
+                    sprintf('%s must implement %s!', $authenticatorConfig['class'], AuthenticatorInterface::class)
+                );
+            }
+            $authenticator = Injector::inst()->get($authenticatorConfig['class']);
+            break;
+        }
+
+        return $authenticator;
+    }
+
+    /**
+     * Sort the configured authenticators by their "priority" (highest to lowest). This allows modules to
+     * contribute to the decision of which authenticator should be used first. Users can rewrite this in their
+     * own configuration if necessary.
+     *
+     * @param array $authenticators
+     */
+    public function prioritiseAuthenticators(&$authenticators)
+    {
+        usort($authenticators, function ($a, $b) {
+            // Set some default values
+            if (!isset($a['priority'])) {
+                $a['priority'] = 10;
+            }
+            if (!isset($b['priority'])) {
+                $b['priority'] = 10;
+            }
+
+            return $a['priority'] < $b['priority'];
+        });
+    }
+}

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -37,6 +37,11 @@ class Manager
     protected $errorFormatter = [self::class, 'formatError'];
 
     /**
+     * @var Member
+     */
+    protected $member;
+
+    /**
      * @param array $config An array with optional 'types' and 'queries' keys
      * @return Manager
      */
@@ -253,12 +258,34 @@ class Manager
     }
 
     /**
+     * Set the Member for the current context
+     *
+     * @param  Member $member
+     * @return $this
+     */
+    public function setMember(Member $member)
+    {
+        $this->member = $member;
+        return $this;
+    }
+
+    /**
+     * Get the Member for the current context either from a previously set value or the current user
+     *
+     * @return Member
+     */
+    public function getMember()
+    {
+        return $this->member ?: Member::currentUser();
+    }
+
+    /**
      * @return array
      */
     protected function getContext()
     {
         return [
-            'currentUser' => Member::currentUser()
+            'currentUser' => $this->getMember()
         ];
     }
 }

--- a/tests/Auth/HandlerTest.php
+++ b/tests/Auth/HandlerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace SilverStripe\GraphQL\Tests\Auth;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Auth\Handler;
+use SilverStripe\GraphQL\Manager;
+use SilverStripe\GraphQL\Tests\Fake\BrutalAuthenticatorFake;
+use SilverStripe\GraphQL\Tests\Fake\PushoverAuthenticatorFake;
+use SilverStripe\Security\Member;
+
+/**
+ * @package silverstripe-graphql
+ */
+class HandlerTest extends SapphireTest
+{
+    /**
+     * @var Handler
+     */
+    protected $handler;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        Config::inst()->nest();
+        Config::inst()->update('SilverStripe\\GraphQL', 'authenticators', null);
+
+        $this->handler = new Handler;
+    }
+
+    /**
+     * Ensure that nothing is done when no authenticators are configured
+     */
+    public function testRequireAuthenticationReturnsFalseWhenNoneAreConfigured()
+    {
+        $this->assertFalse($this->handler->requireAuthentication(new HTTPRequest('GET', '/')));
+    }
+
+    /**
+     * Ensure that a successfully authenticated Member is returned by the Handler
+     */
+    public function testRequireAuthenticationReturnsMember()
+    {
+        Config::inst()->update('SilverStripe\\GraphQL', 'authenticators', [
+            ['class' => PushoverAuthenticatorFake::class]
+        ]);
+
+        $member = $this->handler->requireAuthentication(new HTTPRequest('GET', '/'));
+        $this->assertSame('john@example.com', $member->Email);
+    }
+
+    /**
+     * Ensure that an authenticator is returned when configured correctly
+     */
+    public function testGetAuthenticator()
+    {
+        Config::inst()->update('SilverStripe\\GraphQL', 'authenticators', [
+            ['class' => PushoverAuthenticatorFake::class]
+        ]);
+
+        $result = $this->handler->getAuthenticator();
+        $this->assertInstanceOf(PushoverAuthenticatorFake::class, $result);
+    }
+
+    /**
+     * Test that an exception is thrown if an authenticator is configured that doesn't implement the interface
+     *
+     * @expectedException \SilverStripe\ORM\ValidationException
+     * @expectedExceptionMessage stdClass must implement SilverStripe\GraphQL\Auth\AuthenticatorInterface!
+     */
+    public function testExceptionThrownWhenAuthenticatorDoesNotImplementAuthenticatorInterface()
+    {
+        Config::inst()->update('SilverStripe\\GraphQL', 'authenticators', [
+            ['class' => 'stdClass']
+        ]);
+
+        $this->handler->getAuthenticator();
+    }
+
+    /**
+     * Test that authenticators can be prioritised and that priority is given a default value if not provided
+     *
+     * @param array  $authenticators
+     * @param string $expected
+     * @dataProvider prioritisedAuthenticatorProvider
+     */
+    public function testAuthenticatorsCanBePrioritised($authenticators, $expected)
+    {
+        Config::inst()->update('SilverStripe\\GraphQL', 'authenticators', $authenticators);
+
+        $this->assertInstanceOf($expected, $this->handler->getAuthenticator());
+    }
+
+    /**
+     * @return array
+     */
+    public function prioritisedAuthenticatorProvider()
+    {
+        return [
+            [
+                [
+                    ['class' => PushoverAuthenticatorFake::class, 'priority' => 10],
+                    ['class' => BrutalAuthenticatorFake::class, 'priority' => 100]
+                ],
+                BrutalAuthenticatorFake::class
+            ],
+            [
+                [
+                    ['class' => PushoverAuthenticatorFake::class, 'priority' => 100],
+                    ['class' => BrutalAuthenticatorFake::class, 'priority' => 10]
+                ],
+                PushoverAuthenticatorFake::class
+            ],
+            [
+                [
+                    ['class' => PushoverAuthenticatorFake::class],
+                    ['class' => BrutalAuthenticatorFake::class, 'priority' => 5]
+                ],
+                PushoverAuthenticatorFake::class
+            ],
+            [
+                [
+                    ['class' => PushoverAuthenticatorFake::class, 'priority' => 5],
+                    ['class' => BrutalAuthenticatorFake::class]
+                ],
+                BrutalAuthenticatorFake::class
+            ]
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        Config::inst()->unnest();
+        parent::tearDown();
+    }
+}

--- a/tests/Fake/BrutalAuthenticatorFake.php
+++ b/tests/Fake/BrutalAuthenticatorFake.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\GraphQL\Tests\Fake;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\GraphQL\Auth\AuthenticatorInterface;
+use SilverStripe\Security\Member;
+
+class BrutalAuthenticatorFake implements AuthenticatorInterface, TestOnly
+{
+    public function authenticate(HTTPRequest $request)
+    {
+        return false;
+    }
+}

--- a/tests/Fake/PushoverAuthenticatorFake.php
+++ b/tests/Fake/PushoverAuthenticatorFake.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\GraphQL\Tests\Fake;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\GraphQL\Auth\AuthenticatorInterface;
+use SilverStripe\Security\Member;
+
+class PushoverAuthenticatorFake implements AuthenticatorInterface, TestOnly
+{
+    public function authenticate(HTTPRequest $request)
+    {
+        return Member::create(['Email' => 'john@example.com']);
+    }
+}

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -8,6 +8,7 @@ use SilverStripe\GraphQL\Tests\Fake\QueryCreatorFake;
 use SilverStripe\GraphQL\Tests\Fake\MutationCreatorFake;
 use GraphQL\Type\Definition\Type;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Security\Member;
 use GraphQL\Error;
 use GraphQL\Schema;
 use GraphQL\Language\SourceLocation;
@@ -122,6 +123,19 @@ class ManagerTest extends SapphireTest
 
         $response = $mock->query('');
         $this->assertArrayHasKey('errors', $response);
+    }
+
+    /**
+     * Test the getter and setter for the Member. If not set, Member should be retrieved from the session.
+     */
+    public function testGetAndSetMember()
+    {
+        $manager = new Manager;
+        $this->assertNull($manager->getMember());
+
+        $member = Member::create();
+        $manager->setMember($member);
+        $this->assertSame($member, $manager->getMember());
     }
 
     protected function getType(Manager $manager)


### PR DESCRIPTION
The BasicAuth implementation will adequately protect the API endpoint, and will validate against a Member, but (by design) it will not be stored in the session and as such cannot be used for native SilverStripe permission checking (`Page::canView`).

This change adds an `AuthenticatorInterface` which can be implemented by various authenticator classes to use the `HTTPRequest` provided to GraphQL to authenticate against members, and return a `Member` instance if successful.

This PR includes a `BasicAuthAuthenticator`.

Example configuration:

```yaml
SilverStripe\GraphQL:
  # Enforce HTTP basic authentication for GraphQL requests
  authenticators:
    - class: SilverStripe\GraphQL\Auth\BasicAuthAuthenticator
      priority: 10
```

The only non-obvious implication here is that even if you have a global basic auth requirement set on your site, you'll still need to configure the `BasicAuthAuthenticator` for GraphQL.

The docs have been updated with authentication information, a configuration example, and an example for GraphiQL (app only) client implementation using the base64 encoded header.

---

Starts #6