### PR TITLE
Only call setters once on CaseInsensitiveFieldAccessor

### DIFF
--- a/src/Util/CaseInsensitiveFieldAccessor.php
+++ b/src/Util/CaseInsensitiveFieldAccessor.php
@@ -97,18 +97,14 @@ class CaseInsensitiveFieldAccessor
             ));
         }
 
-        // Correct case for methods (e.g. canView)
         if ($object->hasMethod($objectFieldName)) {
+            // Correct case for methods (e.g. canView)
             $object->{$objectFieldName}($value);
-        }
-
-        // Correct case (and getters)
-        if ($object->hasField($objectFieldName)) {
+        } else if ($object->hasField($objectFieldName)) {
+            // Correct case (and getters)
             $object->{$objectFieldName} = $value;
-        }
-
-        // Infer casing
-        if ($object instanceof DataObject) {
+        } else if ($object instanceof DataObject) {
+            // Infer casing
             $object->setField($objectFieldName, $value);
         }
 


### PR DESCRIPTION
This caused issues with multiple setName() invocations
on Folder: The setter modifies the value. If the setter is then called
again with the same value, it falsifies the results.