### PR TITLE
Use 0.2 branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.1.x-dev"
+      "dev-master": "0.2.x-dev"
     }
   },
   "autoload": {


### PR DESCRIPTION
We'll want to keep 0.1 for a non-stable release line
which is compatible with SilverStripe 3.x.
The backport to 3.x hasn't been started yet,
but we don't want to create separate 1.x and 2.x
release lines just yet since it'll communicate
API stability according to semantic versioning.

Once the 0.1 branch for 3.x goes stable,
we might have a 1.0 release for 3.x,
and a 2.0 release for 4.x compat.