### PR TITLE
FIX Member handler should be checked last

### DIFF
--- a/src/Auth/Handler.php
+++ b/src/Auth/Handler.php
@@ -32,11 +32,11 @@ class Handler
     private static $authenticators = [
         [
             'class' => MemberAuthenticator::class,
-            'priority' => 20,
+            'priority' => 10,
         ],
         [
             'class' => BasicAuthAuthenticator::class,
-            'priority' => 10,
+            'priority' => 20,
         ]
     ];
 


### PR DESCRIPTION
Priority (in its current implementation) is ordered from highest to lowest in order of which authenticators are checked.

`MemberAuthenticator` should be the last class to be checked as it is the fallback authentication option.

Contributes to #60 