### PR TITLE
API Added CORS pre-flight handler (fixes #66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1431,7 +1431,7 @@ Authorization: Basic aGVsbG86d29ybGQ=
 combination of your username, colon and password. The above example is `hello:world`.
 
 **Note:** Authentication credentials are transferred in plain text when using HTTP
-basic authenticaiton. We strongly recommend using TLS for non-development use.
+basic authentication. We strongly recommend using TLS for non-development use.
 
 Example:
 
@@ -1458,6 +1458,106 @@ SilverStripe\GraphQL\Auth\Handler:
   authenticators:
     - class: SilverStripe\GraphQL\Auth\BasicAuthAuthenticator
       priority: 10
+```
+
+## Cross-Origin Resource Sharing (CORS)
+
+By default [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) is disabled in the GraphQL Server. This can be easily enabled via Yaml
+
+```yaml
+   SilverStripe\GraphQL:
+     cors:
+       Enabled: true
+```
+
+Once you have enabled CORS you can then control four new headers in the HTTP Response.
+
+1. **Access-Control-Allow-Origin.**
+
+ This lets you define which domains are allowed to access your GraphQL API. There are
+ 4 options:
+
+ * **Blank**:
+ Deny all domains (except localhost)
+
+ ```yaml
+      Allow-Origin:
+ ```
+
+ * **'\*'**:
+ Allow requests from all domains.
+
+ ```yaml
+      Allow-Origin: '*'
+ ```
+
+ * **Single Domain**:
+
+ Allow requests from one specific external domain.
+
+ ```yaml
+      Allow-Origin: 'my.domain.com'
+ ```
+
+ * **Multiple Domains**:
+
+ Allow requests from multiple specified external domains.
+
+ ```yaml
+      Allow-Origin:
+        - 'my.domain.com'
+        - 'your.domain.org'
+ ```
+
+2. **Access-Control-Allow-Headers.**
+
+ Access-Control-Allow-Headers is part of a CORS 'pre-flight' request to identify
+ what headers a CORS request may include.  By default, the GraphQL server enables the
+ `Authorization` and `Content-Type` headers. You can add extra allowed headers that
+ your GraphQL may need by adding them here. For example:
+
+ ```yaml
+      Allow-Headers: 'Authorization, Content-Type, Content-Language'
+ ```
+
+ **Note** If you add extra headers to your GraphQL server, you will need to write a
+ custom resolver function to handle the response.
+
+3. **Access-Control-Allow-Methods.**
+
+ This defines the HTTP request methods that the GraphQL server will handle.  By
+ default this is set to `GET, PUT, OPTIONS`. Again, if you need to support extra
+ methods you will need to write a custom resolver to handle this. For example:
+
+ ```yaml
+      Allow-Methods: 'GET, PUT, DELETE, OPTIONS'
+ ```
+
+4. **Access-Control-Max-Age.**
+
+ Sets the maximum cache age (in seconds) for the CORS pre-flight response. When
+ the client makes a successful OPTIONS request, it will cache the response
+ headers for this specified duration. If the time expires or the required
+ headers are different for a new CORS request, the client will send a new OPTIONS
+ pre-flight request to ensure it still has authorisation to make the request.
+ This is set to 86400 seconds (24 hours) by default but can be changed in YAML as
+ in this example:
+
+ ```yaml
+      Max-Age: 600
+ ```
+
+#### Sample Custom CORS Config
+
+```yaml
+  ## CORS Config
+  SilverStripe\GraphQL:
+    cors:
+      Enabled: true
+      Allow-Origin: 'silverstripe.org'
+      Allow-Headers: 'Authorization, Content-Type'
+      Allow-Methods:  'GET, POST, OPTIONS'
+      Max-Age:  600  # 600 seconds = 10 minutes.
 ```
 
 ## TODO

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -24,3 +24,12 @@ SilverStripe\ORM\FieldType\DBPrimaryKey:
 
 SilverStripe\ORM\FieldType\DBForeignKey:
   graphql_type: 'ID'
+
+## CORS default config
+SilverStripe\GraphQL:
+  cors:
+    Enabled: false # Off by default
+    Allow-Origin: # Deny all by default
+    Allow-Headers: 'Authorization, Content-Type'
+    Allow-Methods:  'GET, POST, OPTIONS'
+    Max-Age:  86400  # 86,400 seconds = 1 day.

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -36,6 +36,27 @@ class Controller extends BaseController
         if ($stage && in_array($stage, [Versioned::DRAFT, Versioned::LIVE])) {
             Versioned::set_stage($stage);
         }
+
+        // Check for a possible CORS preflight request and handle if necessary
+        // Refer issue 66:  https://github.com/silverstripe/silverstripe-graphql/issues/66
+        $corsConfig = Config::inst()->get('SilverStripe\GraphQL', 'cors');
+        $corsEnabled = true; // Default to have CORS turned on.
+
+        if ($corsConfig && isset($corsConfig['Enabled']) && !$corsConfig['Enabled']) {
+            // Dev has turned off CORS
+            $corsEnabled = false;
+        }
+        if ($corsEnabled && $request->httpMethod() == 'OPTIONS') {
+            // CORS config is enabled and the request is an OPTIONS pre-flight.
+            // Process the CORS config and add appropriate headers.
+            $response = new HTTPResponse();
+            return $this->addCorsHeaders($request, $response);
+        } elseif (!$corsEnabled && $request->httpMethod() == 'OPTIONS') {
+            // CORS is disabled but we have received an OPTIONS request.  This is not a valid request method in this
+            // situation.  Return a 405 Method Not Allowed response.
+            return $this->httpError(405, "Method Not Allowed");
+        }
+
         $contentType = $request->getHeader('Content-Type') ?: $request->getHeader('content-type');
         $isJson = preg_match('#^application/json\b#', $contentType);
         if ($isJson) {
@@ -86,8 +107,8 @@ class Controller extends BaseController
             ];
         }
 
-        return (new HTTPResponse(json_encode($result)))
-            ->addHeader('Content-Type', 'application/json');
+        $response = $this->addCorsHeaders($request, new HTTPResponse(json_encode($result)));
+        return $response->addHeader('Content-Type', 'application/json');
     }
 
     /**
@@ -122,5 +143,53 @@ class Controller extends BaseController
     public function getAuthHandler()
     {
         return new Handler;
+    }
+
+    /**
+     * Process the CORS config options and add the appropriate headers to the response.
+     *
+     * @param HTTPRequest $request
+     * @param HTTPResponse $response
+     * @return HTTPResponse
+     */
+    public function addCorsHeaders(HTTPRequest $request, HTTPResponse $response)
+    {
+        $corsConfig = Config::inst()->get('SilverStripe\GraphQL', 'cors');
+        if (empty($corsConfig['Enabled'])) {
+            // If CORS is disabled don't add the extra headers. Simply return the response untouched.
+            return $response;
+        }
+
+        // Allow Origins header.
+        if (is_string($corsConfig['Allow-Origin'])) {
+            $allowedOrigins = [$corsConfig['Allow-Origin']];
+        } else {
+            $allowedOrigins = $corsConfig['Allow-Origin'];
+        }
+        if (!empty($allowedOrigins)) {
+            $origin = $request->getHeader('Origin');
+            if ($origin) {
+                $originAuthorised = false;
+                foreach ($allowedOrigins as $allowedOrigin) {
+                    if ($allowedOrigin == $origin) {
+                        $response->addHeader("Access-Control-Allow-Origin", $origin);
+                        $originAuthorised = true;
+                        break;
+                    }
+                }
+
+                if (!$originAuthorised) {
+                    return $this->httpError(403, "Access Forbidden");
+                }
+            }
+        } else {
+            return $this->httpError(403, "Access Forbidden");
+        }
+
+        $response->addHeader('Access-Control-Allow-Headers', $corsConfig['Allow-Headers']);
+        $response->addHeader('Access-Control-Allow-Methods', $corsConfig['Allow-Methods']);
+        $response->addHeader('Access-Control-Max-Age', $corsConfig['Max-Age']);
+
+        return $response;
     }
 }


### PR DESCRIPTION
Added code to index() to detect a CORS preflight OPTIONS request.
Added getCorsResponse() to append the correct headers for a CORS request. 
Also checks the origin is an allowed domain for cross-origin requests. 
Included unittests for invalid origin, valid origin, OPTIONS request type.