### PR TITLE
POST queries with variables entity causes error

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -42,7 +42,7 @@ class Controller extends BaseController
             $rawBody = $request->getBody();
             $data = json_decode($rawBody ?: '', true);
             $query = isset($data['query']) ? $data['query'] : null;
-            $variables = isset($data['variables']) ? json_decode($data['variables'], true) : null;
+            $variables = isset($data['variables']) ? $data['variables'] : null;
         } else {
             $query = $request->requestVar('query');
             $variables = json_decode($request->requestVar('variables'), true);


### PR DESCRIPTION
When submitting a query to GraphQL via a POST message, in the case where the 'variables' entity is non-null, an extra call to json_decode is made which is unnecessary and causes a PHP error because the entity is already decoded earlier in the block.