### PR TITLE
Allow wildcard in allowed-origin CORS settings.

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -171,7 +171,7 @@ class Controller extends BaseController
             if ($origin) {
                 $originAuthorised = false;
                 foreach ($allowedOrigins as $allowedOrigin) {
-                    if ($allowedOrigin == $origin) {
+                    if ($allowedOrigin == $origin || $allowedOrigin === '*') {
                         $response->addHeader("Access-Control-Allow-Origin", $origin);
                         $originAuthorised = true;
                         break;

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -200,6 +200,28 @@ class ControllerTest extends SapphireTest
         $this->assertEquals(86400, $response->getHeader('Access-Control-Max-Age'));
     }
 
+    public function testAddCorsHeadersOriginAllowedWildcard()
+    {
+        Config::inst()->remove('SilverStripe\GraphQL', 'cors');
+        Config::inst()->update('SilverStripe\GraphQL', 'cors', [
+            'Enabled' => true,
+            'Allow-Origin' => '*',
+            'Allow-Headers' => 'Authorization, Content-Type',
+            'Allow-Methods' =>  'GET, PUT, OPTIONS',
+            'Max-Age' => 600
+        ]);
+
+        $controller = new Controller();
+        $request = new HTTPRequest('GET', '');
+        $request->addHeader('Origin', 'localhost');
+        $response = new HTTPResponse();
+        $response = $controller->addCorsHeaders($request, $response);
+
+        $this->assertTrue($response instanceof HTTPResponse);
+        $this->assertEquals('200', $response->getStatusCode());
+        $this->assertEquals('localhost', $response->getHeader('Access-Control-Allow-Origin'));
+    }
+
     /**
      * @expectedException SilverStripe\Control\HTTPResponse_Exception
      */


### PR DESCRIPTION
Currently, a wildcard as `Allow-Origin` seems to be ignored. This PR fixes this. 