### PR TITLE
Force $variables to cast as array

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -63,10 +63,10 @@ class Controller extends BaseController
             $rawBody = $request->getBody();
             $data = json_decode($rawBody ?: '', true);
             $query = isset($data['query']) ? $data['query'] : null;
-            $variables = isset($data['variables']) ? $data['variables'] : null;
+            $variables = isset($data['variables']) ? (array) $data['variables'] : null;
         } else {
             $query = $request->requestVar('query');
-            $variables = json_decode($request->requestVar('variables'), true);
+            $variables = json_decode((array) $request->requestVar('variables'), true);
         }
 
         $this->setManager($manager = $this->getManager());


### PR DESCRIPTION
GraphiQL passes variables as empty string and `GraphQL\Validator\Rules\QueryComplexity::setRawVariableValues()` chokes on a non-array value.