### PR TITLE
FIX Allow Authenticator exceptions to be returned to client

### DIFF
--- a/src/Auth/Handler.php
+++ b/src/Auth/Handler.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\GraphQL\Auth;
 
 use SilverStripe\Control\HTTPRequest;
-use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injector;
@@ -13,8 +12,6 @@ use SilverStripe\Security\Member;
 /**
  * The authentication Handler is responsible for handling authentication requirements and providing a Member
  * to the Manager if required, so it can be used in request contexts.
- *
- * @package silverstripe-graphql
  */
 class Handler
 {
@@ -47,9 +44,9 @@ class Handler
      * Authenticators are defined in configuration. @see AuthenticatorInterface::authenticate.
      *
      * @param  HTTPRequest $request
-     * @return Member|false           If authentication was successful the Member is returned. False if no
-     *                                authenticators are configured.
-     * @throws HTTPResponse_Exception If authentication is attempted and fails
+     * @return Member|false         If authentication was successful the Member is returned. False if no
+     *                              authenticators are configured.
+     * @throws ValidationException  If authentication is attempted and fails
      */
     public function requireAuthentication(HTTPRequest $request)
     {
@@ -62,8 +59,8 @@ class Handler
         if ($member instanceof Member) {
             return $member;
         }
-        // Note: The authenticator class itself may also throw an exception
-        throw new HTTPResponse_Exception('Authentication failed.', 401);
+        // Note: The authenticator class itself may also throw an exception when called
+        throw new ValidationException('Authentication failed.', 401);
     }
 
     /**
@@ -88,8 +85,6 @@ class Handler
                 return $authenticator;
             }
         }
-
-        return null;
     }
 
     /**

--- a/tests/Auth/HandlerTest.php
+++ b/tests/Auth/HandlerTest.php
@@ -6,6 +6,7 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Auth\Handler;
 use SilverStripe\GraphQL\Tests\Fake\BrutalAuthenticatorFake;
+use SilverStripe\GraphQL\Tests\Fake\FalsyAuthenticatorFake;
 use SilverStripe\GraphQL\Tests\Fake\PushoverAuthenticatorFake;
 
 /**
@@ -126,5 +127,37 @@ class HandlerTest extends SapphireTest
                 BrutalAuthenticatorFake::class
             ]
         ];
+    }
+
+    /**
+     * Ensure that an failed authentication attempt throws an exception
+     *
+     * @expectedException \SilverStripe\ORM\ValidationException
+     * @expectedExceptionMessage Never!
+     */
+    public function testFailedAuthenticationThrowsException()
+    {
+        Handler::config()->update('authenticators', [
+            ['class' => BrutalAuthenticatorFake::class]
+        ]);
+
+        $this->handler->requireAuthentication(new HTTPRequest('/', 'GET'));
+    }
+
+    /**
+     * Ensure that when a falsy value is returned from an authenticator (when it should throw
+     * an exception on failure) that a sensible default message is used in a ValidationException
+     * instead.
+     *
+     * @expectedException \SilverStripe\ORM\ValidationException
+     * @expectedExceptionMessage Authentication failed.
+     */
+    public function testFailedAuthenticationWithFalsyReturnValueThrowsDefaultException()
+    {
+        Handler::config()->update('authenticators', [
+            ['class' => FalsyAuthenticatorFake::class]
+        ]);
+
+        $this->handler->requireAuthentication(new HTTPRequest('/', 'GET'));
     }
 }

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -140,7 +140,25 @@ class ControllerTest extends SapphireTest
         $response = $controller->index(new HTTPRequest('GET', ''));
 
         $assertion = ($shouldFail) ? 'assertContains' : 'assertNotContains';
-        $this->{$assertion}('Authentication failed', $response->getBody());
+        // See Fake\BrutalAuthenticatorFake::authenticate for failure message
+        $this->{$assertion}('Never!', $response->getBody());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function authenticatorProvider()
+    {
+        return [
+            [
+                Fake\PushoverAuthenticatorFake::class,
+                false,
+            ],
+            [
+                Fake\BrutalAuthenticatorFake::class,
+                true
+            ]
+        ];
     }
 
     /**
@@ -208,23 +226,6 @@ class ControllerTest extends SapphireTest
 
         $this->assertTrue($response instanceof HTTPResponse);
         $this->assertEquals('405', $response->getStatusCode());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function authenticatorProvider()
-    {
-        return [
-            [
-                Fake\PushoverAuthenticatorFake::class,
-                false,
-            ],
-            [
-                Fake\BrutalAuthenticatorFake::class,
-                true,
-            ]
-        ];
     }
 
     protected function getType(Manager $manager)

--- a/tests/Fake/FalsyAuthenticatorFake.php
+++ b/tests/Fake/FalsyAuthenticatorFake.php
@@ -7,11 +7,11 @@ use SilverStripe\Dev\TestOnly;
 use SilverStripe\GraphQL\Auth\AuthenticatorInterface;
 use SilverStripe\ORM\ValidationException;
 
-class BrutalAuthenticatorFake implements AuthenticatorInterface, TestOnly
+class FalsyAuthenticatorFake implements AuthenticatorInterface, TestOnly
 {
     public function authenticate(HTTPRequest $request)
     {
-        throw new ValidationException('Never!');
+        return false;
     }
 
     public function isApplicable(HTTPRequest $request)


### PR DESCRIPTION
AuthenticatorInterface specifies that a ValidationException will be thrown on
authentication failure, yet BasicAuthAuthenticator and stub test classes are
set to return null. Adjusted to match interface.

---

Note: I'm treating this as a fix as it's an incompatibility against the existing
interface API.

Resolves #60

Example client update to suit is in this PR as well as sminnee/silverstripe-apikey#9