### PR TITLE
FIX Correct namespaces in test classes, add PSR-4 autoloader, sort some class imports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,11 @@
       "SilverStripe\\GraphQL\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "SilverStripe\\GraphQL\\Tests\\": "tests/"
+    }
+  },
   "config": {
     "process-timeout": 600
   },

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -1,20 +1,21 @@
 <?php
 
-namespace SilverStripe\GraphQL;
+namespace SilverStripe\GraphQL\Tests;
 
-use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\InputObjectField;
 use GraphQL\Type\Definition\InputObjectType;
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\ORM\ArrayList;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
-use SilverStripe\GraphQL\Pagination\SortInputTypeCreator;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Manager;
 use SilverStripe\GraphQL\Pagination\Connection;
-use SilverStripe\GraphQL\Tests\Fake\TypeCreatorFake;
+use SilverStripe\GraphQL\Pagination\SortInputTypeCreator;
 use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
 use SilverStripe\GraphQL\Tests\Fake\PaginatedQueryFake;
-use GraphQL\Type\Definition\InputObjectField;
-use GraphQL\Type\Definition\FieldDefinition;
-use GraphQL\Type\Definition\ResolveInfo;
+use SilverStripe\GraphQL\Tests\Fake\TypeCreatorFake;
+use SilverStripe\ORM\ArrayList;
 use InvalidArgumentException;
 
 class ConnectionTest extends SapphireTest

--- a/tests/Fake/DataObjectFake.php
+++ b/tests/Fake/DataObjectFake.php
@@ -2,7 +2,9 @@
 
 namespace SilverStripe\GraphQL\Tests\Fake;
 
+use SilverStripe\Assets\File;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\Security\Member;
 use SilverStripe\ORM\DataObject;
 
 class DataObjectFake extends DataObject implements TestOnly
@@ -13,11 +15,11 @@ class DataObjectFake extends DataObject implements TestOnly
     ];
 
     private static $has_one = [
-        'Author' => 'SilverStripe\Security\Member'
+        'Author' => Member::class
     ];
 
     private static $many_many = [
-        'Files' => 'SilverStripe\Assets\File'
+        'Files' => File::class
     ];
 
     public $customSetterFieldResult;
@@ -48,17 +50,17 @@ class DataObjectFake extends DataObject implements TestOnly
     {
         return true;
     }
-    
+
     public function canEdit($member = null)
     {
         return true;
     }
-    
+
     public function canView($member = null)
     {
         return true;
     }
-    
+
     public function canDelete($member = null)
     {
         return true;

--- a/tests/Fake/FakeRedirectorPage.php
+++ b/tests/Fake/FakeRedirectorPage.php
@@ -2,15 +2,16 @@
 
 namespace SilverStripe\GraphQL\Tests\Fake;
 
+use SilverStripe\Dev\TestOnly;
+
 /**
  * Because otherwise we have to include silverstripe-cms as a dependency just
  * to get the test to work.
  */
-class FakeRedirectorPage extends FakePage
+class FakeRedirectorPage extends FakePage implements TestOnly
 {
-
     private static $db = [
-        "RedirectionType" => "Enum('Internal,External','Internal')",
-        "ExternalURL" => "Varchar(2083)"
+        'RedirectionType' => "Enum('Internal,External','Internal')",
+        'ExternalURL' => 'Varchar(2083)'
     ];
 }

--- a/tests/Fake/FakeResolver.php
+++ b/tests/Fake/FakeResolver.php
@@ -2,9 +2,10 @@
 
 namespace SilverStripe\GraphQL\Tests\Fake;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\GraphQL\Scaffolding\Interfaces\ResolverInterface;
 
-class FakeResolver implements ResolverInterface
+class FakeResolver implements ResolverInterface, TestOnly
 {
     public function resolve($object, $args, $context, $info)
     {

--- a/tests/Fake/FakeSiteTree.php
+++ b/tests/Fake/FakeSiteTree.php
@@ -2,9 +2,10 @@
 
 namespace SilverStripe\GraphQL\Tests\Fake;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 
-class FakeSiteTree extends DataObject
+class FakeSiteTree extends DataObject implements TestOnly
 {
     private static $db = [
         'Title' => 'Varchar',

--- a/tests/Fake/MutationCreatorFake.php
+++ b/tests/Fake/MutationCreatorFake.php
@@ -2,9 +2,10 @@
 
 namespace SilverStripe\GraphQL\Tests\Fake;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\GraphQL\MutationCreator;
 
-class MutationCreatorFake extends MutationCreator
+class MutationCreatorFake extends MutationCreator implements TestOnly
 {
     public function type()
     {

--- a/tests/Fake/OperationScaffolderFake.php
+++ b/tests/Fake/OperationScaffolderFake.php
@@ -2,9 +2,10 @@
 
 namespace SilverStripe\GraphQL\Tests\Fake;
 
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\OperationScaffolder;
 
-class OperationScaffolderFake extends OperationScaffolder
+class OperationScaffolderFake extends OperationScaffolder implements TestOnly
 {
 
 }

--- a/tests/Fake/PaginatedQueryFake.php
+++ b/tests/Fake/PaginatedQueryFake.php
@@ -1,14 +1,14 @@
 <?php
 
-
 namespace SilverStripe\GraphQL\Tests\Fake;
 
 use GraphQL\Type\Definition\Type;
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\GraphQL\QueryCreator;
 use SilverStripe\GraphQL\Pagination\PaginatedQueryCreator;
 use SilverStripe\GraphQL\Pagination\Connection;
 
-class PaginatedQueryFake extends PaginatedQueryCreator
+class PaginatedQueryFake extends PaginatedQueryCreator implements TestOnly
 {
     public function createConnection()
     {

--- a/tests/Fake/QueryCreatorFake.php
+++ b/tests/Fake/QueryCreatorFake.php
@@ -3,9 +3,10 @@
 namespace SilverStripe\GraphQL\Tests\Fake;
 
 use GraphQL\Type\Definition\Type;
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\GraphQL\QueryCreator;
 
-class QueryCreatorFake extends QueryCreator
+class QueryCreatorFake extends QueryCreator implements TestOnly
 {
     public function type()
     {

--- a/tests/Fake/TypeCreatorFake.php
+++ b/tests/Fake/TypeCreatorFake.php
@@ -3,9 +3,10 @@
 namespace SilverStripe\GraphQL\Tests\Fake;
 
 use GraphQL\Type\Definition\Type;
+use SilverStripe\Dev\TestOnly;
 use SilverStripe\GraphQL\TypeCreator;
 
-class TypeCreatorFake extends TypeCreator
+class TypeCreatorFake extends TypeCreator implements TestOnly
 {
     public function attributes()
     {

--- a/tests/FieldCreatorTest.php
+++ b/tests/FieldCreatorTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace SilverStripe\GraphQL;
+namespace SilverStripe\GraphQL\Tests;
 
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\FieldCreator;
 
 class FieldCreatorTest extends SapphireTest
 {

--- a/tests/TypeCreatorTest.php
+++ b/tests/TypeCreatorTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace SilverStripe\GraphQL;
+namespace SilverStripe\GraphQL\Tests;
 
 use GraphQL\Type\Definition\InputObjectType;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\TypeCreator;
 use GraphQL\Type\Definition\Type;
 
 class TypeCreatorTest extends SapphireTest

--- a/tests/Util/CaseInsensitiveFieldAccessorTest.php
+++ b/tests/Util/CaseInsensitiveFieldAccessorTest.php
@@ -8,7 +8,6 @@ use SilverStripe\Dev\SapphireTest;
 
 class CaseInsensitiveFieldAccessorTest extends SapphireTest
 {
-
     public function testGetValueWithOriginalCasing()
     {
         $fake = new DataObjectFake([


### PR DESCRIPTION
This pull request:

* implements a dev autoloader
* fixes inconsistent namespaces in test classes
* implements `SilverStripe\Dev\TestOnly` in test stubs
* fixes some PSR-2 compat in stubs
* rearranges some class imports a bit so they're alphabetically ordered