### PR TITLE
Resolve issue #118 CORS issues in IE and Edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1634,6 +1634,21 @@ Once you have enabled CORS you can then control four new headers in the HTTP Res
  Max-Age: 600
  ```
 
+5. **CORS exception for Internet Explorer and Edge**
+
+ IE 11 and Edge fix. When CORS is enabled but we are on the same domain,
+ IE refuses to send the Origin header, causing a lot of pain.
+ 
+ The next best thing, is to validate it's IE or Edge and check the referrer.
+ This is not the safest solution, but it's a workaround.
+ 
+ Note, when it's an actual CORS request, IE does add the header, 
+ so we only use this when it is not an actual CORS request.
+ 
+ [Bug on Microsoft.com](https://connect.microsoft.com/IE/feedback/details/781303/origin-header-is-not-added-to-cors-requests-to-same-domain-but-different-port)
+ 
+ Observed is that this also happens when the port is the same. 
+
 ### Sample Custom CORS Config
 
 ```yaml

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -269,6 +269,101 @@ class ControllerTest extends SapphireTest
         $this->assertEquals('405', $response->getStatusCode());
     }
 
+    /**
+     * IE and Edge are a bit weird, so we check CORS headers differently on the same domain
+     * despite CORS being enabled. This checks if our IE exception plays nice
+     */
+    public function testIECorsHeadersResponseCORSEnabledOnSameDomain()
+    {
+        Controller::config()->set('cors', [
+            'Enabled' => true,
+            'Allow-Origin' => 'localhost',
+            'Allow-Headers' => 'Authorization, Content-Type',
+            'Allow-Methods' =>  'GET, POST, OPTIONS',
+            'Max-Age' => 86400
+        ]);
+
+        $controller = new Controller();
+        $request = new HTTPRequest('OPTIONS', '');
+        $request->addHeader('referer', 'http://localhost/admin/tests');
+        $request->addHeader('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko');
+        $response = $controller->index($request);
+
+        $this->assertTrue($response instanceof HTTPResponse);
+        $this->assertEquals('200', $response->getStatusCode());
+        $this->assertNotEmpty($response->getHeader('Access-Control-Allow-Origin'));
+    }
+
+    /**
+     * IE and Edge are a bit weird, so we check CORS headers differently on the same domain
+     * despite CORS being enabled. This checks if our IE exception plays not nice without the user agent
+     * @expectedException \SilverStripe\Control\HTTPResponse_Exception
+     */
+    public function testIECorsHeadersResponseCORSEnabledNoReferer()
+    {
+        Controller::config()->set('cors', [
+            'Enabled' => true,
+            'Allow-Origin' => 'localhost',
+            'Allow-Headers' => 'Authorization, Content-Type',
+            'Allow-Methods' =>  'GET, POST, OPTIONS',
+            'Max-Age' => 86400
+        ]);
+
+        $controller = new Controller();
+        $request = new HTTPRequest('OPTIONS', '');
+        $request->addHeader('referer', 'http://localhost/admin/tests');
+        $controller->index($request);
+    }
+
+    /**
+     * IE and Edge are a bit weird, so we check CORS headers differently on the same domain
+     * despite CORS being enabled. This checks if our IE exception plays nice
+     */
+    public function testEdgeCorsHeadersResponseCORSEnabledOnSameDomain()
+    {
+        Controller::config()->set('cors', [
+            'Enabled' => true,
+            'Allow-Origin' => 'localhost',
+            'Allow-Headers' => 'Authorization, Content-Type',
+            'Allow-Methods' =>  'GET, POST, OPTIONS',
+            'Max-Age' => 86400
+        ]);
+
+        $controller = new Controller();
+        $request = new HTTPRequest('OPTIONS', '');
+        $request->addHeader('referer', 'http://localhost/admin/tests');
+        // Yes, that is a real Edge user agent string!
+        $request->addHeader('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063');
+        $response = $controller->index($request);
+
+        $this->assertTrue($response instanceof HTTPResponse);
+        $this->assertEquals('200', $response->getStatusCode());
+        $this->assertNotEmpty($response->getHeader('Access-Control-Allow-Origin'));
+    }
+
+    /**
+     * IE and Edge are a bit weird, so we check CORS headers differently on the same domain
+     * despite CORS being enabled. This checks if our IE exception plays nice
+     * @expectedException \SilverStripe\Control\HTTPResponse_Exception
+     */
+    public function testEdgeCorsHeadersResponseCORSEnabledNoReferer()
+    {
+        Controller::config()->set('cors', [
+            'Enabled' => true,
+            'Allow-Origin' => 'localhost',
+            'Allow-Headers' => 'Authorization, Content-Type',
+            'Allow-Methods' =>  'GET, POST, OPTIONS',
+            'Max-Age' => 86400
+        ]);
+
+        $controller = new Controller();
+        $request = new HTTPRequest('OPTIONS', '');
+        // Yes, that is a real Edge user agent string!
+        $request->addHeader('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15063');
+        $controller->index($request);
+    }
+
+
     protected function getType(Manager $manager)
     {
         return (new TypeCreatorFake($manager))->toType();


### PR DESCRIPTION
This pull involves a work-around for IE and Edge browsers not being able to send CORS headers when the root domain is the same, despite CORS headers being required.

It's falling back to referer. This is a security risk, but less of a security risk than simply allowing all when there is a CORS requirement.

This resolves issue #118 which contains more information on how and what this PR resolves.

