### PR TITLE
Expose as vendor module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: false
+dist: trusty
 
 env:
   global:
@@ -19,16 +19,17 @@ matrix:
 before_script:
 # Init PHP
   - composer self-update || true
-  - if [[ $PHPCS_TEST ]]; then pyrus install pear/PHP_CodeSniffer; fi
   - phpenv rehash
   - phpenv config-rm xdebug.ini
 
 # Install composer dependencies
+  - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
   - composer install --prefer-dist
   - composer require --prefer-dist --no-update symfony/config:^3.2 silverstripe/framework:4.0.x-dev silverstripe/versioned:1.0.x-dev silverstripe/assets:1.0.x-dev silverstripe/config:1.0.x-dev --prefer-dist
   - composer update
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
+  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,10 @@
 {
   "name": "silverstripe/graphql",
   "description": "GraphQL server for SilverStripe models and other data",
-  "type": "silverstripe-module",
+  "type": "silverstripe-vendormodule",
   "require": {
     "silverstripe/framework": "^4",
+    "silverstripe/vendor-plugin": "^1.0",
     "webonyx/graphql-php": "~0.8.0"
   },
   "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="framework/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
 
     <testsuite name="Default">
         <directory>tests</directory>


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/7405
Merge after https://github.com/silverstripe/silverstripe-framework/pull/7395
Blocked by https://github.com/silverstripe/silverstripe-graphql/pull/122

Tested file listing in CMS.

Test (after merging the framework pull request):

```
composer config repositories.graphql vcs https://github.com/open-sausages/silverstripe-graphql.git
composer require "silverstripe/graphql:dev-pulls/vendorise-me-baby as 0.2.x-dev"
```