### PR TITLE
BUGFIX: Prevent defaultValue from being added to args when null

### DIFF
--- a/src/Scaffolding/Scaffolders/ArgumentScaffolder.php
+++ b/src/Scaffolding/Scaffolders/ArgumentScaffolder.php
@@ -141,10 +141,15 @@ class ArgumentScaffolder implements ConfigurationApplier
      */
     public function toArray()
     {
-        return [
+        $args = [
             'description' => $this->description,
             'type' => $this->required ? Type::nonNull($this->type) : $this->type,
-            'defaultValue' => $this->defaultValue
         ];
+
+        if ($this->defaultValue !== null) {
+            $args['defaultValue'] = $this->defaultValue;
+        }
+
+        return $args;
     }
 }

--- a/tests/Scaffolding/Scaffolders/ArgumentScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/ArgumentScaffolderTest.php
@@ -36,5 +36,9 @@ class ArgumentScaffolderTest extends SapphireTest
         $this->assertEquals('Bar', $arr['defaultValue']);
         $this->assertInstanceOf(NonNull::class, $arr['type']);
         $this->assertInstanceOf(StringType::class, $arr['type']->getWrappedType());
+
+        $scaffolder->setDefaultValue(null);
+        $arr = $scaffolder->toArray();
+        $this->assertArrayNotHasKey('defaultValue', $arr);
     }
 }


### PR DESCRIPTION
Graphiql coerces `null` into a string `"null"`. It shouldn't be in the schema in the first place if it's null.