### PR TITLE
Add `Access-Control-Allow-Credentials` header

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -31,6 +31,7 @@ class Controller extends BaseController
         'Allow-Origin' => [], // List of all allowed origins; Deny by default
         'Allow-Headers' => 'Authorization, Content-Type',
         'Allow-Methods' => 'GET, POST, OPTIONS',
+        'Allow-Credentials' => '', // Off by default, set to 'true' to allow session cookies from other origins
         'Max-Age' => 86400, // 86,400 seconds = 1 day.
     ];
 
@@ -157,6 +158,7 @@ class Controller extends BaseController
         $response->addHeader('Access-Control-Allow-Origin', $origin);
         $response->addHeader('Access-Control-Allow-Headers', $corsConfig['Allow-Headers']);
         $response->addHeader('Access-Control-Allow-Methods', $corsConfig['Allow-Methods']);
+        $response->addHeader('Access-Control-Allow-Credentials', $corsConfig['Allow-Credentials']);
         $response->addHeader('Access-Control-Max-Age', $corsConfig['Max-Age']);
 
         return $response;

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -295,6 +295,7 @@ class ControllerTest extends SapphireTest
             'Allow-Origin' => '*',
             'Allow-Headers' => 'Authorization, Content-Type',
             'Allow-Methods' =>  'GET, PUT, OPTIONS',
+            'Allow-Credentials' => 'true',
             'Max-Age' => 600
         ]);
 

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -169,6 +169,7 @@ class ControllerTest extends SapphireTest
             'Allow-Origin' => null,
             'Allow-Headers' => 'Authorization, Content-Type',
             'Allow-Methods' =>  'GET, POST, OPTIONS',
+            'Allow-Credentials' => 'true',
             'Max-Age' => 86400
         ]);
 
@@ -189,6 +190,7 @@ class ControllerTest extends SapphireTest
             'Allow-Origin' => 'http://localhost',
             'Allow-Headers' => 'Authorization, Content-Type',
             'Allow-Methods' =>  'GET, POST, OPTIONS',
+            'Allow-Credentials' => 'true',
             'Max-Age' => 86400
         ]);
 
@@ -215,6 +217,7 @@ class ControllerTest extends SapphireTest
             'Allow-Origin' => 'http://localhost',
             'Allow-Headers' => 'Authorization, Content-Type',
             'Allow-Methods' =>  'GET, POST, OPTIONS',
+            'Allow-Credentials' => 'true',
             'Max-Age' => 86400
         ]);
 
@@ -241,6 +244,7 @@ class ControllerTest extends SapphireTest
             'Allow-Origin' => 'http://localhost:8181',
             'Allow-Headers' => 'Authorization, Content-Type',
             'Allow-Methods' =>  'GET, POST, OPTIONS',
+            'Allow-Credentials' => 'true',
             'Max-Age' => 86400
         ]);
 
@@ -257,6 +261,7 @@ class ControllerTest extends SapphireTest
         $this->assertEquals('http://localhost:8181', $response->getHeader('Access-Control-Allow-Origin'));
         $this->assertEquals('Authorization, Content-Type', $response->getHeader('Access-Control-Allow-Headers'));
         $this->assertEquals('GET, POST, OPTIONS', $response->getHeader('Access-Control-Allow-Methods'));
+        $this->assertEquals('true', $response->getHeader('Access-Control-Allow-Credentials'));
         $this->assertEquals(86400, $response->getHeader('Access-Control-Max-Age'));
     }
 
@@ -272,6 +277,7 @@ class ControllerTest extends SapphireTest
             'Allow-Origin' => 'http://localhost:9090',
             'Allow-Headers' => 'Authorization, Content-Type',
             'Allow-Methods' =>  'GET, POST, OPTIONS',
+            'Allow-Credentials' => 'true',
             'Max-Age' => 86400
         ]);
 
@@ -312,6 +318,7 @@ class ControllerTest extends SapphireTest
             'Allow-Origin' => 'localhost',
             'Allow-Headers' => 'Authorization, Content-Type',
             'Allow-Methods' =>  'GET, POST, OPTIONS',
+            'Allow-Credentials' => 'true',
             'Max-Age' => 86400
         ]);
 


### PR DESCRIPTION
Setting `Allow-Credentials` to 'true' will allow applications on other origins to use session cookies for authentication