### PR TITLE
Add editorconfig rule for composer.json to be allowed four spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ trim_trailing_whitespace = true
 [*.{yml,js,json,css,scss}]
 indent_size = 2
 indent_style = space
+
+[composer.json]
+indent_size = 4


### PR DESCRIPTION
Parent issue https://github.com/silverstripe/silverstripe-installer/issues/189