### PR TITLE
Update recipe branching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
   - composer install --prefer-dist
-  - composer require --prefer-dist --no-update silverstripe/recipe-core:1.2.x-dev silverstripe/versioned:1.2.x-dev silverstripe/assets:1.2.x-dev --prefer-dist
+  - composer require --prefer-dist --no-update silverstripe/recipe-core:4.2.x-dev silverstripe/versioned:1.2.x-dev silverstripe/assets:1.2.x-dev --prefer-dist
   - composer update
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --prefer-dist; fi
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi


### PR DESCRIPTION
Parent issue: https://github.com/silverstripe/recipe-core/issues/24

From 4.2 onwards all recipes will use the same numbering as the core framework version.