### PR TITLE
ENHANCEMENT Proof of concept of cached graphql queries

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -12,6 +12,7 @@ use SilverStripe\Core\Injector\Injectable;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Error\Error;
 use GraphQL\Type\Definition\Type;
+use SilverStripe\GraphQL\Middleware\QueryMiddleware;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Security\Member;
 use SilverStripe\GraphQL\Scaffolding\Interfaces\ScaffoldingProvider;
@@ -61,6 +62,61 @@ class Manager
      * @var Member
      */
     protected $member;
+
+
+    /**
+     * @var QueryMiddleware[]
+     */
+    protected $middlewares = [];
+
+    /**
+     * @return QueryMiddleware[]
+     */
+    public function getMiddlewares()
+    {
+        return $this->middlewares;
+    }
+
+    /**
+     * @param QueryMiddleware[] $middlewares
+     * @return $this
+     */
+    public function setMiddlewares($middlewares)
+    {
+        $this->middlewares = $middlewares;
+        return $this;
+    }
+
+    /**
+     * @param QueryMiddleware $middleware
+     * @return $this
+     */
+    public function addMiddleware($middleware)
+    {
+        $this->middlewares[] = $middleware;
+        return $this;
+    }
+
+    /**
+     * Call middleware to evaluate a graphql query
+     *
+     * @param string $query Query to invoke
+     * @param array $params Variables passed to this query
+     * @param callable $last The callback to call after all middlewares
+     * @return ExecutionResult|array
+     */
+    protected function callMiddleware($query, $params, callable $last)
+    {
+        // Reverse middlewares
+        $next = $last;
+        /** @var QueryMiddleware $middleware */
+        foreach (array_reverse($this->getMiddlewares()) as $middleware) {
+            $next = function ($query, $variables) use ($middleware, $next) {
+                return $middleware->process($query, $variables, $next);
+            };
+        }
+        return $next($query, $params);
+    }
 
     /**
      * @param array $config An array with optional 'types' and 'queries' keys
@@ -189,7 +245,10 @@ class Manager
     }
 
     /**
-     * Execute an arbitrary operation (mutation / query) on this schema
+     * Execute an arbitrary operation (mutation / query) on this schema.
+     *
+     * Note because middleware may produce serialised responses we need to conditionally
+     * normalise to serialised array on output from object -> array.
      *
      * @param string $query Raw query
      * @param array $params List of arguments given for this operation
@@ -199,30 +258,29 @@ class Manager
     {
         $executionResult = $this->queryAndReturnResult($query, $params);
 
-        if (!empty($executionResult->errors)) {
-            return [
-                'data' => $executionResult->data,
-                'errors' => array_map($this->errorFormatter, $executionResult->errors),
-            ];
-        } else {
-            return [
-                'data' => $executionResult->data,
-            ];
+        // Already in array form
+        if (is_array($executionResult)) {
+            return $executionResult;
         }
+        return $this->serialiseResult($executionResult);
     }
 
     /**
+     * Evaluate query via middleware
+     *
      * @param string $query
      * @param array $params
-     * @return ExecutionResult
+     * @return ExecutionResult|array Result as either source object result, or serialised as array.
      */
     public function queryAndReturnResult($query, $params = [])
     {
-        $schema = $this->schema();
-        $context = $this->getContext();
-        $result = GraphQL::executeAndReturnResult($schema, $query, null, $context, $params);
+        $last = function ($query, $params) {
+            $schema = $this->schema();
+            $context = $this->getContext();
+            return GraphQL::executeAndReturnResult($schema, $query, null, $context, $params);
+        };
 
-        return $result;
+        return $this->callMiddleware($query, $params, $last);
     }
 
     /**
@@ -257,7 +315,7 @@ class Manager
     }
 
     /**
-     * @param  string  $name
+     * @param  string $name
      *
      * @return boolean
      */
@@ -371,5 +429,26 @@ class Manager
         return [
             'currentUser' => $this->getMember()
         ];
+    }
+
+    /**
+     * Serialise a Graphql result object for output
+     *
+     * @param ExecutionResult $executionResult
+     * @return array
+     */
+    public function serialiseResult($executionResult)
+    {
+        // Format object
+        if (!empty($executionResult->errors)) {
+            return [
+                'data' => $executionResult->data,
+                'errors' => array_map($this->errorFormatter, $executionResult->errors),
+            ];
+        } else {
+            return [
+                'data' => $executionResult->data,
+            ];
+        }
     }
 }

--- a/src/Middleware/QueryMiddleware.php
+++ b/src/Middleware/QueryMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SilverStripe\GraphQL\Middleware;
+
+use GraphQL\Executor\ExecutionResult;
+
+/**
+ * Represents middleware for evaluating a graphql query
+ */
+interface QueryMiddleware
+{
+
+    /**
+     * @param string $query
+     * @param array $params
+     * @param callable $next
+     * @return ExecutionResult|array Result either as an ExecutionResult object or raw array
+     */
+    public function process($query, $params, callable $next);
+}

--- a/src/Middleware/QueryMiddleware.php
+++ b/src/Middleware/QueryMiddleware.php
@@ -3,18 +3,20 @@
 namespace SilverStripe\GraphQL\Middleware;
 
 use GraphQL\Executor\ExecutionResult;
+use GraphQL\Schema;
 
 /**
  * Represents middleware for evaluating a graphql query
  */
 interface QueryMiddleware
 {
-
     /**
+     * @param Schema $schema
      * @param string $query
+     * @param array $context
      * @param array $params
      * @param callable $next
      * @return ExecutionResult|array Result either as an ExecutionResult object or raw array
      */
-    public function process($query, $params, callable $next);
+    public function process(Schema $schema, $query, $context, $params, callable $next);
 }

--- a/tests/Middleware/DummyResponseMiddleware.php
+++ b/tests/Middleware/DummyResponseMiddleware.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SilverStripe\GraphQL\Tests\Middleware;
+
+use GraphQL\Schema;
+use SilverStripe\GraphQL\Middleware\QueryMiddleware;
+
+class DummyResponseMiddleware implements QueryMiddleware
+{
+    public function process(Schema $schema, $query, $context, $params, callable $next)
+    {
+        return ['result' => "It was me, {$params['name']}!"];
+    }
+}

--- a/tests/Middleware/QueryMiddlewareTest.php
+++ b/tests/Middleware/QueryMiddlewareTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SilverStripe\GraphQL\Tests\Middleware;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Manager;
+use SilverStripe\GraphQL\Tests\Fake\MutationCreatorFake;
+use SilverStripe\GraphQL\Tests\Fake\QueryCreatorFake;
+use SilverStripe\GraphQL\Tests\Fake\TypeCreatorFake;
+
+class QueryMiddlewareTest extends SapphireTest
+{
+    public function testMiddlewareResponse()
+    {
+        $config = [
+            'types' => [
+                'mytype' => TypeCreatorFake::class,
+            ],
+            'queries' => [
+                'myquery' => QueryCreatorFake::class,
+            ],
+            'mutations' => [
+                'mymutation' => MutationCreatorFake::class,
+            ],
+        ];
+        $manager = Manager::createFromConfig($config);
+
+        $manager->setMiddlewares([
+            new DummyResponseMiddleware(),
+        ]);
+
+        $this->assertEquals(
+            ['result' => 'It was me, Dio!'],
+            $manager->queryAndReturnResult(
+                '{ query something }',
+                [ 'name' => 'Dio' ]
+            )
+        );
+    }
+}


### PR DESCRIPTION
See #164

Note: This is actually a new minor version (new features) so it should go into a `1` branch (which I haven't created yet), so don't actually merge this please. :)

Tests should come if we think this approach looks good.

I won't post the specifics, but I can confirm that specific queries correctly "spy" on the correct classes queried by the internal graphql.

Another todo is respect versioned deletions (won't affect LastEdited, but will appear as new _Versioned rows). This todo is marked in the code.

@unclecheese / @chillu  / @stevie-mayhew for review.

I've seen performance increases of up to 6x for cached results. ;)