### PR TITLE
FIX DataObjectScaffolder is now injectable, and typos in readme are fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,7 +890,7 @@ $scaffolder
                 'Title' => 'String'
             ])
             ->setResolver(function($object, array $args, $context, ResolveInfo $info) {
-                if (!singleton(Post::class)->canView($context['currentMember'])) {
+                if (!singleton(Post::class)->canView($context['currentUser'])) {
                     throw new \Exception('Cannot view Post');
                 }
                 $list = Post::get();
@@ -970,7 +970,7 @@ $scaffolder
                 'MinimumCommentCount' => 'Use this parameter to specify the minimum number of comments per post'
             ])
             ->setResolver(function($object, array $args, $context, ResolveInfo $info) {
-                if (!singleton(Post::class)->canView($context['currentMember'])) {
+                if (!singleton(Post::class)->canView($context['currentUser'])) {
                     throw new \Exception('Cannot view Post');
                 }
                 $list = Post::get();
@@ -1061,7 +1061,7 @@ $scaffolder
                 'Title' => 'String'
             ])
             ->setResolver(function ($object, array $args, $context, ResolveInfo $info) {
-                if (!singleton(Post::class)->canView($context['currentMember'])) {
+                if (!singleton(Post::class)->canView($context['currentUser'])) {
                     throw new \Exception('Cannot view Post');
                 }
                 $list = Post::get();
@@ -1150,7 +1150,7 @@ $scaffolder
                 'Title' => 'String'
             ])
             ->setResolver(function ($object, array $args, $context, ResolveInfo $info) {
-                if (!singleton(Post::class)->canView($context['currentMember'])) {
+                if (!singleton(Post::class)->canView($context['currentUser'])) {
                     throw new \Exception('Cannot view Post');
                 }
                 $list = Post::get();
@@ -1226,7 +1226,7 @@ SilverStripe\GraphQL\Controller:
           ## ...
         MyProject\Comment:
           ## ...
-        SilverStripe\Security\Member
+        SilverStripe\Security\Member:
           fields: [FirstName, Surname, Name, Email]
         SilverStripe\Assets\File:
           fields: [Filename, URL]
@@ -1261,7 +1261,7 @@ SilverStripe\GraphQL\Controller:
             Comments:
               args:
                 OnlyToday: Boolean
-                resolver: MyProject\CommentResolver
+              resolver: MyProject\CommentResolver
           ##...
         ##...
 ```
@@ -1275,7 +1275,7 @@ $scaffolder
                 'OnlyToday' => 'Boolean'
             ])
             ->setResolver(function($object, array $args, $context, ResolveInfo $info) {
-                if (!singleton(Comment::class)->canView($context['currentMember'])) {
+                if (!singleton(Comment::class)->canView($context['currentUser'])) {
                     throw new \Exception('Cannot view Comment');
                 }
                 $comments = $obj->Comments();
@@ -1365,7 +1365,7 @@ $scaffolder
         ])
         ->setResolver(function ($object, array $args, $context, ResolveInfo $info) {
             $post = Post::get()->byID($args['ID']);
-            if ($post->canEdit($context['currentMember'])) {
+            if ($post->canEdit($context['currentUser'])) {
                 $post->Title = $args['NewTitle'];
                 $post->write();
             }
@@ -1376,7 +1376,7 @@ $scaffolder
     ->query('latestPost', Post::class)
         ->setUsePagination(false)
         ->setResolver(function ($object, array $args, $context, ResolveInfo $info) {
-            if (singleton(Post::class)->canView($context['currentMember'])) {
+            if (singleton(Post::class)->canView($context['currentUser'])) {
                 return Post::get()->sort('Date', 'DESC')->first();
             }
         })

--- a/src/Scaffolding/Scaffolders/SchemaScaffolder.php
+++ b/src/Scaffolding/Scaffolders/SchemaScaffolder.php
@@ -137,7 +137,7 @@ class SchemaScaffolder implements ManagerMutatorInterface
             }
         }
 
-        $scaffold = (new DataObjectScaffolder($class))
+        $scaffold = Injector::inst()->create(DataObjectScaffolder::class, $class)
                 ->setChainableParent($this);
         $this->types[] = $scaffold;
 


### PR DESCRIPTION
The context key is `currentUser`, so updated the examples to reflect this. Also the indentation level for `resolver` is important, and I've made the DataObjectScaffolder instantiation go through injector.