### PR TITLE
FIX Don't rely on return value of GraphQL scaffolding providers

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -148,7 +148,7 @@ class Manager
                         ScaffoldingProvider::class
                     ));
                 }
-                $scaffolder = $provider->provideGraphQLScaffolding($scaffolder);
+                $provider->provideGraphQLScaffolding($scaffolder);
             }
         }
         $scaffolder->addToManager($manager);


### PR DESCRIPTION
Currently the interface doesn't mention a return value on the method `provideGraphQLScaffolding`. This is an issue when the method is actually called as the manager relies on the return value.

This PR removes that reliance (as it probably should be from the get go)

I've targeted 2.0 with this as a patch as the documented API doesn't mention a return value on the interface.