### PR TITLE
API Increase visibility of private properties, used by ReadVersions in silverstripe/versioned

### DIFF
--- a/src/Scaffolding/Traits/DataObjectTypeTrait.php
+++ b/src/Scaffolding/Traits/DataObjectTypeTrait.php
@@ -16,12 +16,12 @@ trait DataObjectTypeTrait
     /**
      * @var string
      */
-    private $dataObjectClass;
+    protected $dataObjectClass;
 
     /**
      * @var DataObject
      */
-    private $dataObjectInstance;
+    protected $dataObjectInstance;
 
     /**
      * @return string


### PR DESCRIPTION
The `ReadVersions` ListQueryScaffolder implementation in silverstripe/versioned sets these properties, since they're private it'd be creating its own version of them. This leads to a fragile API surface.

We prefer not to use private visiblity in SilverStripe code, so this is increasing it to protected.