### PR TITLE
FIX Quote injector alias references, deprecated and removed support for in Symfony 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ public-facing GraphQL server that ships with the module, just add a rule to `Dir
 ```yaml
 SilverStripe\Control\Director:
   rules:
-    'graphql': %$SilverStripe\GraphQL\Controller.default
+    'graphql': '%$SilverStripe\GraphQL\Controller.default'
 ```
 
 ## Examples
@@ -2144,7 +2144,7 @@ Lastly, we'll need to route the controller.
 ```yaml
 SilverStripe\Control\Director:
   rules:
-    'my-graphql': %$SilverStripe\GraphQL\Controller.myApp
+    'my-graphql': '%$SilverStripe\GraphQL\Controller.myApp'
 ```
 
 Now, configure your schema.

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -14,7 +14,7 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\GraphQL\Controller.default:
     class: SilverStripe\GraphQL\Controller
     constructor:
-      manager: %$SilverStripe\GraphQL\Manager.default
+      manager: '%$SilverStripe\GraphQL\Manager.default'
 # Assign each DBField subclass with an associated internal type
 SilverStripe\ORM\FieldType\DBField:
   extensions:


### PR DESCRIPTION
```
PHP Deprecated: Not quoting the scalar "%$SilverStripe\GraphQL\Manager.admin" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 on line 9. in /Users/robbieaverill/dev/ss43/vendor/symfony/yaml/Inline.php on line 357
PHP Deprecated: Not quoting the scalar "%$SilverStripe\GraphQL\Controller.admin" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 on line 4. in /Users/robbieaverill/dev/ss43/vendor/symfony/yaml/Inline.php on line 357
PHP Deprecated: Not quoting the scalar "%$SilverStripe\GraphQL\Manager.default" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0 on line 14. in /Users/robbieaverill/dev/ss43/vendor/symfony/yaml/Inline.php on line 357
```