### PR TITLE
API Scaffolders can now be more expressive when registering fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,64 @@ class Post extends DataObject implements ScaffoldingProvider
 }
 ```
 
+#### Setting field casting
+
+Adding field casting may be necessary if the type of the GraphQL field should be different from the type of the field 
+within your DataObject:
+
+**Via YAML**:
+```yaml
+SilverStripe\GraphQL\Manager:
+  schemas:
+    default:
+      scaffolding:
+        types:
+          MyProject\Post:
+            fields:
+              ID: 
+                description: The unique identifier of the post
+                casting: Int
+              Title: 
+                description: The title of the post as a boolean for some reason
+                casting: Boolean
+            operations:
+              read: true
+              create: true
+```
+
+**...Or with code**:
+
+```php
+namespace MyProject;
+
+use SilverStripe\GraphQL\Scaffolding\Interfaces\ScaffoldingProvider;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
+use SilverStripe\ORM\DataObject;
+
+class Post extends DataObject implements ScaffoldingProvider
+{
+    //...
+    public function provideGraphQLScaffolding(SchemaScaffolder $scaffolder)
+    {
+        $scaffolder
+            ->type(Post::class)
+                ->addFields([
+                    'ID' => [
+                        'description' => 'The unique identifier of the post',
+                        'casting' => 'Int',
+                    ],
+                ])
+                ->scaffoldField('Title', 'The title of the post as a boolean for some reason', DBBoolean::class)
+                ->operation(SchemaScaffolder::READ)
+                    ->end()
+                ->operation(SchemaScaffolder::UPDATE)
+                    ->end()
+                ->end();
+
+            return $scaffolder;
+    }
+}
+
 #### Wildcarding and whitelisting fields
 
 If you have a type you want to be fairly well exposed, it can be tedious to add each

--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -1,0 +1,69 @@
+<?php
+namespace SilverStripe\GraphQL;
+
+use GraphQL\Type\Definition\Type;
+
+class FieldDefinition
+{
+    /**
+     * Self documenting description for this field
+     *
+     * @var string
+     */
+    protected $description;
+
+    /**
+     * The GraphQL type (or string the type can be resolved from) of this field
+     *
+     * @var Type|string
+     */
+    protected $type;
+
+    /**
+     * A callable that can be used to resolve the value of this field. Takes the following parameters:
+     *
+     *  - $object mixed - The object to resolve the field from - eg. the DataObject
+     *  - $args array -
+     *  - $context array - Context for this resolve - includes details like `currentUser` (logged in `Member`)
+     *  - $info GraphQL\Type\Definition\ResolveInfo - Additional info to be used for resolving this
+     *
+     * @var callable
+     */
+    protected $resolver;
+
+    /**
+     * @param string $description
+     * @param Type|string $type
+     * @param callable $resolver
+     */
+    public function __construct($description, $type, callable $resolver)
+    {
+        $this->description = $description;
+        $this->type = $type;
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return Type|string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return callable
+     */
+    public function getResolver()
+    {
+        return $this->resolver;
+    }
+}

--- a/src/FieldDefinition.php
+++ b/src/FieldDefinition.php
@@ -2,6 +2,7 @@
 namespace SilverStripe\GraphQL;
 
 use GraphQL\Type\Definition\Type;
+use SilverStripe\GraphQL\Scaffolding\Extensions\TypeCreatorExtension;
 
 class FieldDefinition
 {
@@ -15,7 +16,7 @@ class FieldDefinition
     /**
      * The GraphQL type (or string the type can be resolved from) of this field
      *
-     * @var Type|string
+     * @var Type|TypeCreatorExtension|string
      */
     protected $type;
 
@@ -33,7 +34,7 @@ class FieldDefinition
 
     /**
      * @param string $description
-     * @param Type|string $type
+     * @param Type|TypeCreatorExtension|string $type
      * @param callable $resolver
      */
     public function __construct($description, $type, callable $resolver)
@@ -52,7 +53,7 @@ class FieldDefinition
     }
 
     /**
-     * @return Type|string
+     * @return Type|TypeCreatorExtension|string
      */
     public function getType()
     {

--- a/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
+++ b/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
@@ -698,13 +698,13 @@ class DataObjectScaffolder implements ManagerMutatorInterface, ScaffolderInterfa
         };
 
         foreach ($this->fields as $fieldName => $definition) {
-            StaticSchema::inst()->assertValidFieldName($instance, $fieldName);
-
             // Allow FieldDefinitions
             if ($definition instanceof FieldDefinition) {
                 $type = $definition->getType();
 
-                if (is_string($type)) {
+                if ($type instanceof DBField || DBField::has_extension($type, TypeCreatorExtension::class)) {
+                    $type = $type->getGraphQLType($manager);
+                } elseif (is_string($type)) {
                     $type = $manager->getType($type);
                 }
 
@@ -719,6 +719,8 @@ class DataObjectScaffolder implements ManagerMutatorInterface, ScaffolderInterfa
                 ];
                 continue;
             }
+
+            StaticSchema::inst()->assertValidFieldName($instance, $fieldName);
 
             // Otherwise "definition" is just the description
             $description = $definition;

--- a/src/Scaffolding/Scaffolders/DataObjectScaffolder/FieldDefinition.php
+++ b/src/Scaffolding/Scaffolders/DataObjectScaffolder/FieldDefinition.php
@@ -1,9 +1,12 @@
 <?php
-namespace SilverStripe\GraphQL;
+namespace SilverStripe\GraphQL\Scaffolding\Scaffolders\DataObjectScaffolder;
 
 use GraphQL\Type\Definition\Type;
 use SilverStripe\GraphQL\Scaffolding\Extensions\TypeCreatorExtension;
 
+/**
+ * Defines a field that will be scaffolded using the DataObjectScaffolder. Create a
+ */
 class FieldDefinition
 {
     /**
@@ -15,6 +18,11 @@ class FieldDefinition
 
     /**
      * The GraphQL type (or string the type can be resolved from) of this field
+     *
+     * This can be:
+     *  - A GraphQL type object
+     *  - A string that can be used to retrieve the type from the GraphQL manager ($manager->getGraphQLType())
+     *  - An object that has the `TypeCreatorExtension` extension
      *
      * @var Type|TypeCreatorExtension|string
      */
@@ -33,6 +41,7 @@ class FieldDefinition
     protected $resolver;
 
     /**
+     * @param string $name
      * @param string $description
      * @param Type|TypeCreatorExtension|string $type
      * @param callable $resolver
@@ -50,6 +59,17 @@ class FieldDefinition
     public function getDescription()
     {
         return $this->description;
+    }
+
+    /**
+     * @param string $description
+     * @return $this
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
     }
 
     /**

--- a/src/Scaffolding/Scaffolders/InheritanceScaffolder.php
+++ b/src/Scaffolding/Scaffolders/InheritanceScaffolder.php
@@ -52,7 +52,6 @@ class InheritanceScaffolder extends UnionScaffolder implements ManagerMutatorInt
      */
     public function getRootClass()
     {
-
         return $this->rootClass;
     }
 

--- a/src/Scaffolding/StaticSchema.php
+++ b/src/Scaffolding/StaticSchema.php
@@ -136,6 +136,27 @@ class StaticSchema
     }
 
     /**
+     * Throws an InvalidArgumentException given the given field name is not valid for the given instance
+     *
+     * @param ViewableData $instance
+     * @param $fieldName
+     */
+    public function assertValidFieldName(ViewableData $instance, $fieldName)
+    {
+        if ($this->isValidFieldName($instance, $fieldName)) {
+            return;
+        }
+
+        throw new InvalidArgumentException(
+            sprintf(
+                'Invalid field "%s" on %s',
+                $fieldName,
+                get_class($instance)
+            )
+        );
+    }
+
+    /**
      * @param array $typesMap An associate array of classname => type name
      * @return $this
      */

--- a/src/Scaffolding/StaticSchema.php
+++ b/src/Scaffolding/StaticSchema.php
@@ -140,6 +140,7 @@ class StaticSchema
      *
      * @param ViewableData $instance
      * @param $fieldName
+     * @throws InvalidArgumentException
      */
     public function assertValidFieldName(ViewableData $instance, $fieldName)
     {


### PR DESCRIPTION
This adds the ability to register a new `FieldDefinition` when adding fields with a scaffolder. This means you can explicitly specify the type AND the resolver for the field rather than relying on it's resolution through the field type of the field on the dataobject.

Part of the reasoning for this PR is it allows scaffolders to define types (ie. boolean, text, int) rather than using `->obj` which falls back to "text" for everything that has no casting (or `$db`) defined. Eg:

```
$scaffolder->addField('MethodAccess', Type::bool(), function($obj) { 
     return $obj->myMethod();
}
```

This PR also tidies up how the fields are retained within the scaffolder, rather than being a non-associative array and then making sure the array is distinct on the field name, I updated it to just be associative by field name. Slight performance gain I suspect.

Fixes #162