### PR TITLE
NEW: Split up resolveList() into separate methods

### DIFF
--- a/src/Pagination/Connection.php
+++ b/src/Pagination/Connection.php
@@ -441,7 +441,7 @@ class Connection implements OperationResolver
      * @param array $args
      * @return array
      */
-    public function getPageinfo($list, array $args)
+    private function getPageinfo($list, array $args)
     {
         $nextPage = false;
         $previousPage = false;

--- a/src/Pagination/Connection.php
+++ b/src/Pagination/Connection.php
@@ -468,7 +468,7 @@ class Connection implements OperationResolver
      * @param array $args
      * @return int
      */
-    protected function getLimit(array $args)
+    private function getLimit(array $args)
     {
         $limit = (isset($args['limit']) && $args['limit']) ? $args['limit'] : $this->defaultLimit;
 

--- a/src/Pagination/Connection.php
+++ b/src/Pagination/Connection.php
@@ -484,7 +484,7 @@ class Connection implements OperationResolver
      * @param array $args
      * @return int
      */
-    protected function getOffset(array $args)
+    private function getOffset(array $args)
     {
         return (isset($args['offset'])) ? $args['offset'] : 0;
     }


### PR DESCRIPTION
`resolveToList` is designed to return a data structure that only pertains to a GraphQL response. This allows other services to consume only the list mutation operations.