### PR TITLE
Optimise imports over test classes, remove manual require calls and rename base test class

### DIFF
--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\InputObjectField;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\Type;
+use InvalidArgumentException;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Manager;
 use SilverStripe\GraphQL\Pagination\Connection;
@@ -15,7 +16,6 @@ use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
 use SilverStripe\GraphQL\Tests\Fake\PaginatedQueryFake;
 use SilverStripe\GraphQL\Tests\Fake\TypeCreatorFake;
 use SilverStripe\ORM\ArrayList;
-use InvalidArgumentException;
 
 class ConnectionTest extends SapphireTest
 {

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -22,7 +22,6 @@ use SilverStripe\GraphQL\Middleware\CSRFMiddleware;
 use SilverStripe\GraphQL\Middleware\HTTPMethodMiddleware;
 use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
-use SilverStripe\GraphQL\Tests\Fake\FakePersistedQuery;
 use SilverStripe\GraphQL\Tests\Fake\QueryCreatorFake;
 use SilverStripe\GraphQL\Tests\Fake\TypeCreatorFake;
 use SilverStripe\Security\SecurityToken;

--- a/tests/Fake/DataObjectFake.php
+++ b/tests/Fake/DataObjectFake.php
@@ -4,9 +4,9 @@ namespace SilverStripe\GraphQL\Tests\Fake;
 
 use SilverStripe\Assets\File;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ManyManyList;
 use SilverStripe\Security\Member;
-use SilverStripe\ORM\DataObject;
 
 /**
  * @property string $MyField

--- a/tests/Fake/FakeRedirectorPage.php
+++ b/tests/Fake/FakeRedirectorPage.php
@@ -2,13 +2,11 @@
 
 namespace SilverStripe\GraphQL\Tests\Fake;
 
-use SilverStripe\Dev\TestOnly;
-
 /**
  * Because otherwise we have to include silverstripe-cms as a dependency just
  * to get the test to work.
  */
-class FakeRedirectorPage extends FakePage implements TestOnly
+class FakeRedirectorPage extends FakePage
 {
     private static $table_name = "GraphQL_FakeRedirectorPage";
 

--- a/tests/Fake/PaginatedQueryFake.php
+++ b/tests/Fake/PaginatedQueryFake.php
@@ -4,8 +4,8 @@ namespace SilverStripe\GraphQL\Tests\Fake;
 
 use GraphQL\Type\Definition\Type;
 use SilverStripe\Dev\TestOnly;
-use SilverStripe\GraphQL\Pagination\PaginatedQueryCreator;
 use SilverStripe\GraphQL\Pagination\Connection;
+use SilverStripe\GraphQL\Pagination\PaginatedQueryCreator;
 
 class PaginatedQueryFake extends PaginatedQueryCreator implements TestOnly
 {

--- a/tests/Fake/RestrictedDataObjectFake.php
+++ b/tests/Fake/RestrictedDataObjectFake.php
@@ -2,9 +2,7 @@
 
 namespace SilverStripe\GraphQL\Tests\Fake;
 
-use SilverStripe\Dev\TestOnly;
-
-class RestrictedDataObjectFake extends DataObjectFake implements TestOnly
+class RestrictedDataObjectFake extends DataObjectFake
 {
     private static $table_name = "GraphQL_RestrictedDataObjectFake";
 

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -3,24 +3,20 @@
 namespace SilverStripe\GraphQL\Tests;
 
 use GraphQL\Error\Error;
+use GraphQL\Language\SourceLocation;
 use GraphQL\Schema;
 use GraphQL\Type\Definition\Type;
+use InvalidArgumentException;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Manager;
-use SilverStripe\GraphQL\PersistedQuery\FileProvider;
-use SilverStripe\GraphQL\PersistedQuery\HTTPProvider;
-use SilverStripe\GraphQL\PersistedQuery\JSONStringProvider;
 use SilverStripe\GraphQL\PersistedQuery\PersistedQueryMappingProvider;
-use SilverStripe\GraphQL\Tests\Fake\FakePersistedQuery;
 use SilverStripe\GraphQL\Tests\Fake\MutationCreatorFake;
 use SilverStripe\GraphQL\Tests\Fake\QueryCreatorFake;
 use SilverStripe\GraphQL\Tests\Fake\TypeCreatorFake;
 use SilverStripe\Security\IdentityStore;
 use SilverStripe\Security\Member;
-use GraphQL\Language\SourceLocation;
-use InvalidArgumentException;
 
 class ManagerTest extends SapphireTest
 {

--- a/tests/Middleware/CSRFMiddlewareTest.php
+++ b/tests/Middleware/CSRFMiddlewareTest.php
@@ -1,13 +1,12 @@
 <?php
+
 namespace SilverStripe\GraphQL\Tests\Middleware;
 
-require_once(__DIR__ . '/MiddlewareProcessTest.php');
-
+use Exception;
 use SilverStripe\GraphQL\Middleware\CSRFMiddleware;
 use SilverStripe\Security\SecurityToken;
-use Exception;
 
-class CSRFMiddlewareTest extends MiddlewareProcessTest
+class CSRFMiddlewareTest extends MiddlewareProcessTestBase
 {
     public function testItDoesntDoAnythingIfNotAMutation()
     {

--- a/tests/Middleware/HTTPMethodMiddlewareTest.php
+++ b/tests/Middleware/HTTPMethodMiddlewareTest.php
@@ -1,12 +1,11 @@
 <?php
+
 namespace SilverStripe\GraphQL\Tests\Middleware;
 
-require_once(__DIR__ . '/MiddlewareProcessTest.php');
-
-use SilverStripe\GraphQL\Middleware\HTTPMethodMiddleware;
 use Exception;
+use SilverStripe\GraphQL\Middleware\HTTPMethodMiddleware;
 
-class HTTPMethodMiddlewareTest extends MiddlewareProcessTest
+class HTTPMethodMiddlewareTest extends MiddlewareProcessTestBase
 {
     public function testItDoesntDoAnythingIfNotAMutation()
     {

--- a/tests/Middleware/MiddlewareProcessTestBase.php
+++ b/tests/Middleware/MiddlewareProcessTestBase.php
@@ -1,13 +1,14 @@
 <?php
+
 namespace SilverStripe\GraphQL\Tests\Middleware;
 
+use GraphQL\Schema;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Middleware\QueryMiddleware;
-use GraphQL\Schema;
-use GraphQL\Type\Definition\Type;
-use GraphQL\Type\Definition\ObjectType;
 
-abstract class MiddlewareProcessTest extends SapphireTest
+abstract class MiddlewareProcessTestBase extends SapphireTest
 {
     /**
      * @var callable

--- a/tests/Middleware/QueryMiddlewareTest.php
+++ b/tests/Middleware/QueryMiddlewareTest.php
@@ -23,8 +23,9 @@ class QueryMiddlewareTest extends SapphireTest
                 'mymutation' => MutationCreatorFake::class,
             ],
         ];
-        $manager = Manager::createFromConfig($config);
 
+        $manager = new Manager();
+        $manager->applyConfig($config);
         $manager->setMiddlewares([
             new DummyResponseMiddleware(),
         ]);

--- a/tests/PersistedQuery/HTTPProviderTest.php
+++ b/tests/PersistedQuery/HTTPProviderTest.php
@@ -2,11 +2,11 @@
 
 namespace SilverStripe\GraphQL\Tests\PersistedQuery;
 
+use InvalidArgumentException;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\PersistedQuery\HTTPClient;
 use SilverStripe\GraphQL\PersistedQuery\HTTPProvider;
-use InvalidArgumentException;
 
 class HTTPProviderTest extends SapphireTest
 {

--- a/tests/PersistedQuery/JSONStringProviderTest.php
+++ b/tests/PersistedQuery/JSONStringProviderTest.php
@@ -2,8 +2,8 @@
 
 namespace SilverStripe\GraphQL\Tests\PersistedQuery;
 
-use SilverStripe\Dev\SapphireTest;
 use InvalidArgumentException;
+use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\PersistedQuery\JSONStringProvider;
 use SilverStripe\GraphQL\PersistedQuery\PersistedQueryMappingProvider;
 

--- a/tests/Scaffolding/Extensions/TypeCreatorExtensionTest.php
+++ b/tests/Scaffolding/Extensions/TypeCreatorExtensionTest.php
@@ -2,14 +2,14 @@
 
 namespace SilverStripe\GraphQL\Tests\Scaffolding\Extensions;
 
+use GraphQL\Type\Definition\IntType;
 use GraphQL\Type\Definition\ObjectType;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Manager;
 use SilverStripe\GraphQL\Scaffolding\Extensions\TypeCreatorExtension;
 use SilverStripe\GraphQL\Scaffolding\Interfaces\TypeParserInterface;
 use SilverStripe\GraphQL\Scaffolding\StaticSchema;
-use SilverStripe\Core\Config\Config;
-use GraphQL\Type\Definition\IntType;
 use SilverStripe\ORM\FieldType\DBInt;
 
 class TypeCreatorExtensionTest extends SapphireTest

--- a/tests/Scaffolding/Scaffolders/ArgumentScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/ArgumentScaffolderTest.php
@@ -3,13 +3,13 @@
 namespace SilverStripe\GraphQL\Tests\Scaffolders\Scaffolding;
 
 use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\StringType;
 use GraphQL\Type\Definition\Type;
+use InvalidArgumentException;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Manager;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\ArgumentScaffolder;
-use GraphQL\Type\Definition\StringType;
-use GraphQL\Type\Definition\NonNull;
-use InvalidArgumentException;
 
 class ArgumentScaffolderTest extends SapphireTest
 {

--- a/tests/Scaffolding/Scaffolders/CRUD/ReadOneTest.php
+++ b/tests/Scaffolding/Scaffolders/CRUD/ReadOneTest.php
@@ -4,13 +4,13 @@ namespace SilverStripe\GraphQL\Tests\Scaffolding\Scaffolders\CRUD;
 
 use GraphQL\Type\Definition\IDType;
 use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\StringType;
-use SilverStripe\GraphQL\Manager;
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
 use GraphQL\Type\Definition\ObjectType;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\ReadOne;
 use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\StringType;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Manager;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\ReadOne;
+use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
 use SilverStripe\GraphQL\Tests\Fake\RestrictedDataObjectFake;
 use SilverStripe\Security\Member;
 

--- a/tests/Scaffolding/Scaffolders/CRUD/ReadTest.php
+++ b/tests/Scaffolding/Scaffolders/CRUD/ReadTest.php
@@ -2,17 +2,13 @@
 
 namespace SilverStripe\GraphQL\Tests\Scaffolding\Scaffolders\CRUD;
 
-use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
 use GraphQL\Type\Definition\StringType;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Manager;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Read;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\DataObjectScaffolder;
 use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
-use SilverStripe\GraphQL\Tests\Fake\FakePage;
-use SilverStripe\GraphQL\Tests\Fake\FakeRedirectorPage;
 use SilverStripe\GraphQL\Tests\Fake\RestrictedDataObjectFake;
 use SilverStripe\ORM\DataList;
 use SilverStripe\Security\Member;

--- a/tests/Scaffolding/Scaffolders/CRUD/UpdateTest.php
+++ b/tests/Scaffolding/Scaffolders/CRUD/UpdateTest.php
@@ -2,21 +2,21 @@
 
 namespace SilverStripe\GraphQL\Tests\Scaffolding\Scaffolders\CRUD;
 
+use Exception;
 use GraphQL\Type\Definition\IDType;
 use GraphQL\Type\Definition\InputObjectType;
-use SilverStripe\GraphQL\Manager;
+use GraphQL\Type\Definition\IntType;
+use GraphQL\Type\Definition\NonNull;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\StringType;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Manager;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Update;
 use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
 use SilverStripe\GraphQL\Tests\Fake\FakeCRUDExtension;
 use SilverStripe\GraphQL\Tests\Fake\RestrictedDataObjectFake;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Update;
-use GraphQL\Type\Definition\StringType;
-use GraphQL\Type\Definition\NonNull;
-use GraphQL\Type\Definition\IntType;
-use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\ResolveInfo;
 use SilverStripe\Security\Member;
-use Exception;
 
 class UpdateTest extends SapphireTest
 {

--- a/tests/Scaffolding/Scaffolders/DataObjectScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/DataObjectScaffolderTest.php
@@ -2,26 +2,26 @@
 
 namespace SilverStripe\GraphQL\Tests\Scaffolders\Scaffolding;
 
-use SilverStripe\Core\Config\Config;
-use SilverStripe\GraphQL\Manager;
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\GraphQL\Scaffolding\Extensions\TypeCreatorExtension;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\DataObjectScaffolder;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\OperationScaffolder;
-use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
-use SilverStripe\GraphQL\Tests\Fake\FakeSiteTree;
-use SilverStripe\GraphQL\Tests\Fake\FakePage;
-use SilverStripe\GraphQL\Tests\Fake\FakeRedirectorPage;
-use InvalidArgumentException;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\QueryScaffolder;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Create;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Read;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Update;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Delete;
+use Exception;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\ResolveInfo;
-use Exception;
+use InvalidArgumentException;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Manager;
+use SilverStripe\GraphQL\Scaffolding\Extensions\TypeCreatorExtension;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Create;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Delete;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Read;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Update;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\DataObjectScaffolder;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\OperationScaffolder;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\QueryScaffolder;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
+use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
+use SilverStripe\GraphQL\Tests\Fake\FakePage;
+use SilverStripe\GraphQL\Tests\Fake\FakeRedirectorPage;
+use SilverStripe\GraphQL\Tests\Fake\FakeSiteTree;
 use SilverStripe\ORM\FieldType\DBInt;
 
 class DataObjectScaffolderTest extends SapphireTest

--- a/tests/Scaffolding/Scaffolders/InheritanceScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/InheritanceScaffolderTest.php
@@ -3,8 +3,8 @@
 namespace SilverStripe\GraphQL\Tests\Scaffolding\Scaffolding;
 
 use GraphQL\Type\Definition\ObjectType;
-use SilverStripe\Dev\SapphireTest;
 use InvalidArgumentException;
+use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Controller;
 use SilverStripe\GraphQL\Manager;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\InheritanceScaffolder;

--- a/tests/Scaffolding/Scaffolders/ListQueryScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/ListQueryScaffolderTest.php
@@ -2,11 +2,11 @@
 
 namespace SilverStripe\GraphQL\Tests\Scaffolders\Scaffolding;
 
-use SilverStripe\GraphQL\Manager;
-use SilverStripe\Dev\SapphireTest;
-use InvalidArgumentException;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\ListQueryScaffolder;
 use GraphQL\Type\Definition\ObjectType;
+use InvalidArgumentException;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Manager;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\ListQueryScaffolder;
 
 class ListQueryScaffolderTest extends SapphireTest
 {

--- a/tests/Scaffolding/Scaffolders/MutationScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/MutationScaffolderTest.php
@@ -2,10 +2,10 @@
 
 namespace SilverStripe\GraphQL\Tests\Scaffolders\Scaffolding;
 
-use SilverStripe\GraphQL\Manager;
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\MutationScaffolder;
 use GraphQL\Type\Definition\ObjectType;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Manager;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\MutationScaffolder;
 
 class MutationScaffolderTest extends SapphireTest
 {

--- a/tests/Scaffolding/Scaffolders/OperationScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/OperationScaffolderTest.php
@@ -2,22 +2,22 @@
 
 namespace SilverStripe\GraphQL\Tests\Scaffolders\Scaffolding;
 
+use Exception;
 use GraphQL\Type\Definition\BooleanType;
 use GraphQL\Type\Definition\NonNull;
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
-use SilverStripe\GraphQL\Tests\Fake\OperationScaffolderFake;
-use SilverStripe\GraphQL\Tests\Fake\FakeResolver;
+use GraphQL\Type\Definition\StringType;
 use InvalidArgumentException;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\OperationScaffolder;
+use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\ArgumentScaffolder;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Create;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Delete;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Read;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Update;
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Delete;
-use GraphQL\Type\Definition\StringType;
-use Exception;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\OperationScaffolder;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
+use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
+use SilverStripe\GraphQL\Tests\Fake\FakeResolver;
+use SilverStripe\GraphQL\Tests\Fake\OperationScaffolderFake;
 use SilverStripe\GraphQL\Tests\Fake\RestrictedDataObjectFake;
 
 /**

--- a/tests/Scaffolding/Scaffolders/UnionScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/UnionScaffolderTest.php
@@ -2,16 +2,16 @@
 
 namespace SilverStripe\GraphQL\Tests\Scaffolders\Scaffolding;
 
-use SilverStripe\GraphQL\Scaffolding\Scaffolders\UnionScaffolder;
+use Exception;
+use GraphQL\Type\Definition\ResolveInfo;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Manager;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\DataObjectScaffolder;
+use SilverStripe\GraphQL\Scaffolding\Scaffolders\UnionScaffolder;
+use SilverStripe\GraphQL\Tests\Fake\FakePage;
 use SilverStripe\GraphQL\Tests\Fake\FakeRedirectorPage;
 use SilverStripe\GraphQL\Tests\Fake\FakeSiteTree;
-use SilverStripe\GraphQL\Tests\Fake\FakePage;
 use SilverStripe\GraphQL\Tests\Fake\RestrictedDataObjectFake;
-use GraphQL\Type\Definition\ResolveInfo;
-use Exception;
 
 class UnionScaffolderTest extends SapphireTest
 {

--- a/tests/Scaffolding/StaticSchemaTest.php
+++ b/tests/Scaffolding/StaticSchemaTest.php
@@ -3,10 +3,9 @@
 namespace SilverStripe\GraphQL\Tests\Scaffolding;
 
 use GraphQL\Type\Definition\ObjectType;
-use const Grpc\STATUS_INTERNAL;
+use InvalidArgumentException;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
-use InvalidArgumentException;
 use SilverStripe\GraphQL\Manager;
 use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;

--- a/tests/Scaffolding/Util/ArrayTypeParserTest.php
+++ b/tests/Scaffolding/Util/ArrayTypeParserTest.php
@@ -6,8 +6,8 @@ use GraphQL\Type\Definition\FieldDefinition;
 use GraphQL\Type\Definition\IntType;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\StringType;
-use SilverStripe\Dev\SapphireTest;
 use InvalidArgumentException;
+use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Scaffolding\Util\ArrayTypeParser;
 
 /**
@@ -30,7 +30,7 @@ class ArrayTypeParserTest extends SapphireTest
         $type = $parser->getType();
 
         $this->assertInstanceOf(ObjectType::class, $type);
-        
+
         $this->assertInstanceOf(FieldDefinition::class, $type->getField('FieldOne'));
         $this->assertInstanceOf(FieldDefinition::class, $type->getField('FieldTwo'));
 

--- a/tests/Scaffolding/Util/OperationListTest.php
+++ b/tests/Scaffolding/Util/OperationListTest.php
@@ -2,8 +2,8 @@
 
 namespace SilverStripe\GraphQL\Tests\Scaffolding\Util;
 
-use SilverStripe\Dev\SapphireTest;
 use InvalidArgumentException;
+use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\MutationScaffolder;
 use SilverStripe\GraphQL\Scaffolding\Util\OperationList;
 

--- a/tests/Scaffolding/Util/StringTypeParserTest.php
+++ b/tests/Scaffolding/Util/StringTypeParserTest.php
@@ -2,10 +2,10 @@
 
 namespace SilverStripe\GraphQL\Tests\Scaffolding\Util;
 
-use SilverStripe\Dev\SapphireTest;
-use InvalidArgumentException;
-use SilverStripe\GraphQL\Scaffolding\Util\StringTypeParser;
 use GraphQL\Type\Definition\StringType;
+use InvalidArgumentException;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Scaffolding\Util\StringTypeParser;
 
 /**
  * @skipUpgrade

--- a/tests/TypeCreatorTest.php
+++ b/tests/TypeCreatorTest.php
@@ -3,10 +3,10 @@
 namespace SilverStripe\GraphQL\Tests;
 
 use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\Type;
 use PHPUnit_Framework_MockObject_MockObject;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\TypeCreator;
-use GraphQL\Type\Definition\Type;
 
 class TypeCreatorTest extends SapphireTest
 {

--- a/tests/Util/CaseInsensitiveFieldAccessorTest.php
+++ b/tests/Util/CaseInsensitiveFieldAccessorTest.php
@@ -2,9 +2,9 @@
 
 namespace SilverStripe\GraphQL\Tests\Util;
 
-use SilverStripe\GraphQL\Util\CaseInsensitiveFieldAccessor;
-use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
+use SilverStripe\GraphQL\Util\CaseInsensitiveFieldAccessor;
 
 class CaseInsensitiveFieldAccessorTest extends SapphireTest
 {


### PR DESCRIPTION
This ensures it will still be autoloaded and removes the need for the require_once() calls. Optimised imports over all test classes, fixing ordering, removing unused imports and non existent classes and constants.

It also removes implementations of TestOnly where the parent class already implements it.