### PR TITLE
API Don't create "peripheral" operations by default

### DIFF
--- a/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
+++ b/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
@@ -412,6 +412,10 @@ class DataObjectScaffolder implements ManagerMutatorInterface, ScaffolderInterfa
             }
         }
         foreach ($this->getOperations() as $op) {
+            if (!$op->getCloneable()) {
+                continue;
+            }
+
             $identifier = OperationScaffolder::getIdentifier($op);
             $target->operation($identifier);
         }

--- a/src/Scaffolding/Scaffolders/OperationScaffolder.php
+++ b/src/Scaffolding/Scaffolders/OperationScaffolder.php
@@ -49,6 +49,30 @@ abstract class OperationScaffolder implements ConfigurationApplier
     protected $args = [];
 
     /**
+     * @var bool Indicates that this operation should be
+     * included in clones to other types.
+     */
+    protected $cloneable = false;
+
+    /**
+     * @return bool
+     */
+    public function getCloneable()
+    {
+        return $this->cloneable;
+    }
+
+    /**
+     * @param bool $cloneable
+     */
+    public function setCloneable($cloneable)
+    {
+        $this->cloneable = $cloneable;
+
+        return $this;
+    }
+
+    /**
      * @param string $name
      * @return  string|null
      */
@@ -399,11 +423,17 @@ abstract class OperationScaffolder implements ConfigurationApplier
                 }
             }
         }
+
         if (isset($config['resolver'])) {
             $this->setResolver($config['resolver']);
         }
+
         if (isset($config['name'])) {
             $this->setName($config['name']);
+        }
+
+        if (isset($config['cloneable'])) {
+            $this->setCloneable((bool)$config['cloneable']);
         }
 
         return $this;

--- a/src/Scaffolding/Scaffolders/OperationScaffolder.php
+++ b/src/Scaffolding/Scaffolders/OperationScaffolder.php
@@ -64,6 +64,7 @@ abstract class OperationScaffolder implements ConfigurationApplier
 
     /**
      * @param bool $cloneable
+     * @return $this
      */
     public function setCloneable($cloneable)
     {

--- a/src/Scaffolding/Scaffolders/SchemaScaffolder.php
+++ b/src/Scaffolding/Scaffolders/SchemaScaffolder.php
@@ -60,6 +60,7 @@ class SchemaScaffolder implements ManagerMutatorInterface
      */
     public static function createFromConfig($config)
     {
+        /** @var self $scaffolder */
         $scaffolder = Injector::inst()->get(self::class);
         if (isset($config['types'])) {
             if (!ArrayLib::is_associative($config['types'])) {
@@ -284,6 +285,7 @@ class SchemaScaffolder implements ManagerMutatorInterface
     public function addToManager(Manager $manager)
     {
         $this->registerFixedTypes($manager);
+
         $this->registerPeripheralTypes($manager);
 
         $this->extend('onBeforeAddToManager', $manager);

--- a/tests/Scaffolding/Scaffolders/DataObjectScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/DataObjectScaffolderTest.php
@@ -480,7 +480,22 @@ class DataObjectScaffolderTest extends SapphireTest
 
         $this->assertContains('Title', $target->getFields()->column('Name'));
         $this->assertNotContains('RedirectionType', $target->getFields()->column('Name'));
-        $this->assertCount(2, $target->getOperations());
+        $this->assertCount(0, $target->getOperations(), 'Does not clone operations by default');
+    }
+
+    public function testCloneToWithCloneable()
+    {
+        $scaffolder = new DataObjectScaffolder(FakeSiteTree::class);
+        $scaffolder->addFields(['Title', 'ID']);
+        $scaffolder->operation(SchemaScaffolder::READ);
+        $scaffolder->operation(SchemaScaffolder::UPDATE)->setCloneable(true);
+
+        $target = new DataObjectScaffolder(FakeRedirectorPage::class);
+        $target = $scaffolder->cloneTo($target);
+        $this->assertEquals(
+            ['updateSilverStripeFakeRedirectorPage'],
+            $target->getOperations()->column('getName')
+        );
     }
 
     /**

--- a/tests/Scaffolding/Scaffolders/SchemaScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/SchemaScaffolderTest.php
@@ -86,8 +86,10 @@ class SchemaScaffolderTest extends SapphireTest
             ->type(FakeRedirectorPage::class)
                 ->addFields(['Created', 'TestPageField', 'RedirectionType'])
                 ->operation(SchemaScaffolder::CREATE)
+                    ->setCloneable(true)
                     ->end()
                 ->operation(SchemaScaffolder::READ)
+                    ->setCloneable(true)
                     ->end()
                 ->end()
             ->type(DataObjectFake::class)
@@ -284,9 +286,11 @@ class SchemaScaffolderTest extends SapphireTest
             ->addFields(['Title', 'RedirectionType'])
             ->operation(SchemaScaffolder::READ)
                 ->setName('READ')
+                ->setCloneable(true)
             ->end()
             ->operation(SchemaScaffolder::DELETE)
                 ->setName('DELETE')
+                ->setCloneable(true)
             ->end()
             ->end();
         $scaffolder->addToManager($manager = new Manager());


### PR DESCRIPTION
When scaffolding Page with a read operation,
the default behaviour used to be the creation of readPage, readSiteTree, readRedirectorPage etc.
In fact, the readPage query is sufficient, since it returns a union of all these types. The rest is noise,
with the slight advantage that types at the end of an inheritance chain (without descendants)
get away without unions in the return type.

The default behaviour is a bit more useful on create and update operations,
since those require a specific input type - unions aren't allowed here.
So in order to fully create subclasses, you need createPage vs. createRedirectorPage.

I'm proposing that we make this well-documented opt-in behaviour,
with the admin/graphql schema opting in for each type on create and update.
I don't see a reason why anyone would want to opt in on read or delete.

For the more common case where scaffolding is used to create a more limited readonly public schema,
this reduces the mental overhead for devs, noise in the schema itself,
and cuts down schema generation time because less "helper types" like readRedirectorPageConnectionType are required.

If this PR is accepted, we'll need to add the following to the
upgrading guide at https://github.com/silverstripe/silverstripe-graphql/releases/edit/untagged-b4d095bafd3edac22f15

---


Previously, scaffolded operations on `DataObject` would 
create the equivalent operations on both ancestors and descendants.
If you want `readPage`, you'd also get `readSiteTree` and `readRedirectorPage`.
That's often not desired, so we're making it opt-in via a new `cloneable` config setting.
Note that it's most common to clone `create` and `update` operations,
since those rely on specific input types for a class
(e.g. `createPage` has `createPageInputType`, while `createRedirectorPage` has `createRedirectorPageInputType`).

```graphql
SilverStripe\GraphQL\Manager:
  schemas:
    default:
      scaffolding:
        types:
          Page:
            operations:
              read:
              	cloneable: true
```