### PR TITLE
FIX Check readOne permissions against resolved DataObject

### DIFF
--- a/src/Scaffolding/Scaffolders/CRUD/ReadOne.php
+++ b/src/Scaffolding/Scaffolders/CRUD/ReadOne.php
@@ -60,16 +60,20 @@ class ReadOne extends ItemQueryScaffolder implements OperationResolver, CRUDInte
      */
     public function resolve($object, array $args, $context, ResolveInfo $info)
     {
-        if (!$this->getDataObjectInstance()->canView($context['currentUser'])) {
+        // get as a list so extensions can influence it pre-query
+        $list = DataList::create($this->getDataObjectClass())
+            ->filter('ID', $args['ID']);
+        $this->extend('updateList', $list, $args, $context, $info);
+
+        $item = $list->first();
+
+        // Check permissions on the individual item as some permission checks may investigate saved state
+        if (!$item->canView($context['currentUser'])) {
             throw new Exception(sprintf(
                 'Cannot view %s',
                 $this->getDataObjectClass()
             ));
         }
-        // get as a list so extensions can influence it pre-query
-        $list = DataList::create($this->getDataObjectClass())
-            ->filter('ID', $args['ID']);
-        $this->extend('updateList', $list, $args, $context, $info);
 
         return $list->first();
     }


### PR DESCRIPTION
In most cases the canView permission was intended to be checked against the actual object from the database as the object state may have some play on whether the object is accessible by the user.

This was reported in an issue on silverstripe-elemental: https://github.com/dnadesign/silverstripe-elemental/issues/586 . I also have a "custom resolver" fix in that repo but I figure this is a common use case and it's a pretty quick win to get this fixed here.