### PR TITLE
FIX Fall back to checking a singleton for canView() if no specific item exists

### DIFF
--- a/src/Scaffolding/Scaffolders/CRUD/ReadOne.php
+++ b/src/Scaffolding/Scaffolders/CRUD/ReadOne.php
@@ -65,7 +65,8 @@ class ReadOne extends ItemQueryScaffolder implements OperationResolver, CRUDInte
             ->filter('ID', $args['ID']);
         $this->extend('updateList', $list, $args, $context, $info);
 
-        $item = $list->first();
+        // Fall back to getting an empty singleton to use for permission checking
+        $item = $list->first() ?: $this->getDataObjectInstance();
 
         // Check permissions on the individual item as some permission checks may investigate saved state
         if (!$item->canView($context['currentUser'])) {


### PR DESCRIPTION
This restores the similar fallback behaviour before https://github.com/silverstripe/silverstripe-graphql/pull/207 was merged, but still gives priority to the specific item you are viewing if it exists