### PR TITLE
FIX: Return HTTP 400 for an incomplete query

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -301,6 +301,10 @@ class Manager implements ConfigurationApplier
                     }, $this->queries);
                 },
             ]);
+        } else {
+            $schema[self::QUERY_ROOT] = new ObjectType([
+                'name' => 'Query',
+            ]);
         }
 
         if (!empty($this->mutations)) {
@@ -311,6 +315,10 @@ class Manager implements ConfigurationApplier
                         return is_callable($mutation) ? $mutation() : $mutation;
                     }, $this->mutations);
                 },
+            ]);
+        } else {
+            $schema[self::MUTATION_ROOT] = new ObjectType([
+                'name' => 'Mutation',
             ]);
         }
 


### PR DESCRIPTION
This prevents exceptions from being thrown for issues caused by invalid
user-input, preventing spam from being introduced to error monitors
such as Raygun.

This fixes #218 