### PR TITLE
allow CORS headers to be extended via an extension

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -224,6 +224,8 @@ class Controller extends BaseController implements Flushable
         $response->addHeader('Access-Control-Allow-Methods', $corsConfig['Allow-Methods']);
         $response->addHeader('Access-Control-Max-Age', $corsConfig['Max-Age']);
 
+        $this->extend('updateCorsHeaders', $response);
+
         return $response;
     }
 


### PR DESCRIPTION
I'd like to be able to add specific headers for some CORS headers.

Currently we can only allow certain headers - I'd like to add a header like so:

```
Access-Control-Allow-Credentials: 'true'
```

I've simply added in an extension hook to the `addCorsHeaders` function in the Controller.

We could also have this set up as key-value pairs in the module configuration. 

Any thoughts?