### PR TITLE
BUGFIX: Allow mutations to be null. 

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -316,10 +316,6 @@ class Manager implements ConfigurationApplier
                     }, $this->mutations);
                 },
             ]);
-        } else {
-            $schema[self::MUTATION_ROOT] = new ObjectType([
-                'name' => 'Mutation',
-            ]);
         }
 
         return new Schema($schema);


### PR DESCRIPTION
`graphql-devtools` chokes on it otherwise