### PR TITLE
Revert "NEW: Refactor OperationScaffolder subclasses to use resolved type name"

### DIFF
--- a/src/Scaffolding/Scaffolders/CRUD/Create.php
+++ b/src/Scaffolding/Scaffolders/CRUD/Create.php
@@ -41,7 +41,7 @@ class Create extends MutationScaffolder implements OperationResolver, CRUDInterf
             return $name;
         }
 
-        return 'create' . ucfirst($this->getResolvedTypeName());
+        return 'create' . ucfirst($this->getTypeName());
     }
 
     /**
@@ -107,7 +107,7 @@ class Create extends MutationScaffolder implements OperationResolver, CRUDInterf
      */
     protected function inputTypeName()
     {
-        return $this->getResolvedTypeName() . 'CreateInputType';
+        return $this->getTypeName() . 'CreateInputType';
     }
 
     public function resolve($object, array $args, $context, ResolveInfo $info)

--- a/src/Scaffolding/Scaffolders/CRUD/Delete.php
+++ b/src/Scaffolding/Scaffolders/CRUD/Delete.php
@@ -39,7 +39,7 @@ class Delete extends MutationScaffolder implements OperationResolver, CRUDInterf
             return $name;
         }
 
-        return 'delete' . ucfirst($this->getResolvedTypeName());
+        return 'delete' . ucfirst($this->getTypeName());
     }
 
     /**

--- a/src/Scaffolding/Scaffolders/CRUD/Read.php
+++ b/src/Scaffolding/Scaffolders/CRUD/Read.php
@@ -45,7 +45,7 @@ class Read extends ListQueryScaffolder implements OperationResolver, CRUDInterfa
             return $name;
         }
 
-        $typePlural = $this->pluralise($this->getResolvedTypeName());
+        $typePlural = $this->pluralise($this->getTypeName());
         return 'read' . ucfirst($typePlural);
     }
 

--- a/src/Scaffolding/Scaffolders/CRUD/ReadOne.php
+++ b/src/Scaffolding/Scaffolders/CRUD/ReadOne.php
@@ -34,7 +34,7 @@ class ReadOne extends ItemQueryScaffolder implements OperationResolver, CRUDInte
             return $name;
         }
 
-        return 'readOne' . ucfirst($this->getResolvedTypeName());
+        return 'readOne' . ucfirst($this->getTypeName());
     }
 
     /**

--- a/src/Scaffolding/Scaffolders/CRUD/Update.php
+++ b/src/Scaffolding/Scaffolders/CRUD/Update.php
@@ -42,7 +42,7 @@ class Update extends MutationScaffolder implements OperationResolver, CRUDInterf
             return $name;
         }
 
-        return 'update' . ucfirst($this->getResolvedTypeName());
+        return 'update' . ucfirst($this->getTypeName());
     }
 
     /**
@@ -114,7 +114,7 @@ class Update extends MutationScaffolder implements OperationResolver, CRUDInterf
      */
     protected function inputTypeName()
     {
-        return $this->getResolvedTypeName() . 'UpdateInputType';
+        return $this->getTypeName() . 'UpdateInputType';
     }
 
     /**

--- a/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
+++ b/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
@@ -82,7 +82,7 @@ class DataObjectScaffolder implements ManagerMutatorInterface, ScaffolderInterfa
      */
     public function getTypeName()
     {
-        return $this->getDataObjectTypeName();
+        return $this->typeName();
     }
 
     /**

--- a/src/Scaffolding/Scaffolders/ListQueryScaffolder.php
+++ b/src/Scaffolding/Scaffolders/ListQueryScaffolder.php
@@ -130,7 +130,7 @@ class ListQueryScaffolder extends QueryScaffolder
             } else {
                 throw new InvalidArgumentException(sprintf(
                     'sortableFields must be an array (see %s)',
-                    $this->getResolvedTypeName()
+                    $this->getTypeName()
                 ));
             }
         }

--- a/src/Scaffolding/Scaffolders/MutationScaffolder.php
+++ b/src/Scaffolding/Scaffolders/MutationScaffolder.php
@@ -61,15 +61,9 @@ class MutationScaffolder extends OperationScaffolder implements ManagerMutatorIn
         ];
     }
 
-    /**
-     * If a type name has not been assigned, fallback to the typename that gets generated
-     * off the dataobject
-     *
-     * @return string
-     */
-    protected function getResolvedTypeName()
+    public function getTypeName()
     {
-        return $this->getTypeName() ?: $this->getDataObjectTypeName();
+        return parent::getTypeName() ?: $this->typeName();
     }
 
     /**

--- a/src/Scaffolding/Scaffolders/QueryScaffolder.php
+++ b/src/Scaffolding/Scaffolders/QueryScaffolder.php
@@ -71,15 +71,9 @@ abstract class QueryScaffolder extends OperationScaffolder implements ManagerMut
         return $this;
     }
 
-    /**
-     * If a type name has not been assigned, fallback to the typename that gets generated
-     * off the dataobject
-     *
-     * @return string
-     */
-    protected function getResolvedTypeName()
+    public function getTypeName()
     {
-        return $this->getTypeName() ?: $this->getDataObjectTypeName();
+        return parent::getTypeName() ?: $this->typeName();
     }
 
     /**

--- a/src/Scaffolding/Traits/DataObjectTypeTrait.php
+++ b/src/Scaffolding/Traits/DataObjectTypeTrait.php
@@ -33,10 +33,11 @@ trait DataObjectTypeTrait
 
     /**
      * Type name inferred from the dataobject.
+     * This should not be called directly, but only by getTypeName()
      *
      * @return string
      */
-    public function getDataObjectTypeName()
+    protected function typeName()
     {
         $dataObjectClass = $this->getDataObjectClass();
         if (!$dataObjectClass) {


### PR DESCRIPTION
This introduced a number of regressions due to scaffolded queries no longer returning unions.

How we handle inheritance and unions has turned into a bigger discussion that will likely result in a more aggressive, lower-level change. https://github.com/silverstripe/silverstripe-graphql/issues/215

Given the short shelf life of both this change, or the bug that it was trying to fix, the best option here seems to be to revert this and aim to solve it properly.