### PR TITLE
NEW Added ability to disable type caching on flush

### DIFF
--- a/_config/dev.yml
+++ b/_config/dev.yml
@@ -1,0 +1,10 @@
+---
+Name: graphqltest
+Before:
+  - '#sapphiretest'
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Dev\State\SapphireTestState:
+    properties:
+      States:
+        disabletypecaching: '%$SilverStripe\GraphQL\Dev\State\DisableTypeCacheState'

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -12,6 +12,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\GraphQL\Auth\Handler;
+use SilverStripe\GraphQL\Dev\State\DisableTypeCacheState;
 use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\ORM\Connect\DatabaseException;
 use SilverStripe\Security\Member;
@@ -50,6 +51,15 @@ class Controller extends BaseController implements Flushable
      * @config
      */
     private static $cache_types_in_filesystem = false;
+
+    /**
+     * Toggles caching types to the file system on flush
+     * This is set to false in test state @see DisableTypeCacheState
+     *
+     * @var bool
+     * @config
+     */
+    private static $cache_on_flush = true;
 
     /**
      * @var Manager
@@ -451,6 +461,10 @@ class Controller extends BaseController implements Flushable
 
     public static function flush()
     {
+        if (!self::config()->get('cache_on_flush')) {
+            return;
+        }
+
         // This is a bit of a hack to find all registered GraphQL servers. Depends on them
         // being routed through Director.
         $routes = Director::config()->get('rules');

--- a/src/Dev/State/DisableTypeCacheState.php
+++ b/src/Dev/State/DisableTypeCacheState.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace SilverStripe\GraphQL\Dev\State;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\State\TestState;
+use SilverStripe\GraphQL\Controller;
+
+class DisableTypeCacheState implements TestState
+{
+
+    /**
+     * Called on setup
+     *
+     * @param SapphireTest $test
+     */
+    public function setUp(SapphireTest $test)
+    {
+        // no-op
+    }
+
+    /**
+     * Called on tear down
+     *
+     * @param SapphireTest $test
+     */
+    public function tearDown(SapphireTest $test)
+    {
+        // no-op
+    }
+
+    /**
+     * Called once on setup
+     *
+     * @param string $class Class being setup
+     */
+    public function setUpOnce($class)
+    {
+        Config::modify()->set(Controller::class, 'cache_on_flush', false);
+    }
+
+    /**
+     * Called once on tear down
+     *
+     * @param string $class Class being torn down
+     */
+    public function tearDownOnce($class)
+    {
+        // no-op
+    }
+}


### PR DESCRIPTION
This also adds test state to set that new configuration option to false during test runs.

With recipe-kitchen-sink just running configuration for a single test class takes me 8s on my local machine. The test doesn't touch GraphQL at all plus the configuration done by the GraphQL module is only revelant for e2e tests as it's generating a cache file for client side consumption (with Apollo).