### PR TITLE
Minor: Removing duplicate read me content

### DIFF
--- a/README.md
+++ b/README.md
@@ -2559,20 +2559,6 @@ To disable that requirement, you can remove the `HTTPMethodMiddleware` from your
         HTTPMethodMiddleware: false
 ```
 
-## Strict HTTP Method Checking
-
-According to GraphQL best practices, mutations should be done over `POST`, while queries have the option
-to use either `GET` or `POST`. By default, this module enforces the `POST` request method for all mutations.
-
-To disable that requirement, you can remove the `HTTPMethodMiddleware` from your `Manager` implementation.
-
-```yaml
-  SilverStripe\GraphQL\Manager:
-    properties:
-      Middlewares:
-        HTTPMethodMiddleware: false
-```
-
 ## TODO
 
  * Permission checks


### PR DESCRIPTION
Removing duplicate `Strict HTTP Method Checking` content in the read me file, which appears twice in a row.