### PR TITLE
Update Travis to Xenial, use PHP 7.2 / 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: php
 
-dist: trusty
+dist: xenial
+
+services:
+  - mysql
+  - postgresql
 
 env:
   global:
@@ -9,11 +13,11 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1.2
+    - php: 7.2
       env: DB=PGSQL PHPUNIT_TEST=1 PHPCS_TEST=1
-    - php: 7.1.2
+    - php: 7.3
       env: DB=MYSQL PHPUNIT_TEST=1
-    - php: 7.1.2
+    - php: 7.3
       env: DB=MYSQL PDO=1 PHPUNIT_COVERAGE_TEST=1
 
 before_script:


### PR DESCRIPTION
The master branch is testing against CMS 5, which at some point introduced a minimum PHP requirement of 7.2. This PR updates the Travis config from 7.1, in order to (hopefully) get the tests green again.