### PR TITLE
Operation extension points

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -128,6 +128,8 @@ class Manager implements ConfigurationApplier
      */
     protected function callMiddleware(Schema $schema, $query, $context, $params, callable $last)
     {
+        $this->extend('onBeforeCallMiddleware', $schema, $query, $context, $params);
+
         // Reverse middlewares
         $next = $last;
         // Filter out any middlewares that are set to `false`, e.g. via config
@@ -138,7 +140,12 @@ class Manager implements ConfigurationApplier
                 return $middleware->process($schema, $query, $context, $params, $next);
             };
         }
-        return $next($schema, $query, $context, $params);
+
+        $result = $next($schema, $query, $context, $params);
+
+        $this->extend('onAfterCallMiddleware', $schema, $query, $context, $params);
+
+        return $result;
     }
 
     /**

--- a/src/Scaffolding/Scaffolders/CRUD/Create.php
+++ b/src/Scaffolding/Scaffolders/CRUD/Create.php
@@ -130,6 +130,10 @@ class Create extends MutationScaffolder implements OperationResolver, CRUDInterf
 
         // Save and return
         $newObject->write();
-        return DataObject::get_by_id($this->getDataObjectClass(), $newObject->ID);
+        $newObject = DataObject::get_by_id($this->getDataObjectClass(), $newObject->ID);
+
+        $this->extend('afterMutation', $newObject, $args, $context, $info);
+
+        return $newObject;
     }
 }

--- a/src/Scaffolding/Scaffolders/CRUD/Delete.php
+++ b/src/Scaffolding/Scaffolders/CRUD/Delete.php
@@ -65,7 +65,7 @@ class Delete extends MutationScaffolder implements OperationResolver, CRUDInterf
 
     public function resolve($object, array $args, $context, ResolveInfo $info)
     {
-        DB::get_conn()->withTransaction(function () use ($args, $context) {
+        DB::get_conn()->withTransaction(function () use ($args, $context, $info) {
             // Build list to filter
             $results = DataList::create($this->getDataObjectClass())
                 ->byIDs($args['IDs']);
@@ -93,6 +93,8 @@ class Delete extends MutationScaffolder implements OperationResolver, CRUDInterf
             foreach ($resultsList as $obj) {
                 $obj->delete();
             }
+
+            $this->extend('afterMutation', $resultsList, $args, $context, $info);
         });
     }
 }

--- a/src/Scaffolding/Scaffolders/CRUD/Update.php
+++ b/src/Scaffolding/Scaffolders/CRUD/Update.php
@@ -153,6 +153,9 @@ class Update extends MutationScaffolder implements OperationResolver, CRUDInterf
 
         $obj->update($input);
         $obj->write();
+
+        $this->extend('afterMutation', $obj, $args, $context, $info);
+
         return $obj;
     }
 }


### PR DESCRIPTION
* several new extension points added
* these extension points allow to execute some custom code related to handling of user actions
* no functional changes apart from following fix
* fixed an issue in `Scaffolding/Scaffolders/CRUD/Delete.php` where variable `$info` wasn't passed into a function callback which prevented an existing extension point from ever passing this data through
* these changes are required for https://github.com/silverstripe/silverstripe-versioned-snapshots/pull/25