### PR TITLE
fix deprecation in config

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -15,7 +15,7 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\GraphQL\PersistedQuery\JSONStringProvider
   SilverStripe\GraphQL\PersistedQuery\HTTPProvider:
     constructor:
-      httpClient: %$SilverStripe\GraphQL\PersistedQuery\GuzzleHTTPClient
+      httpClient: '%$SilverStripe\GraphQL\PersistedQuery\GuzzleHTTPClient'
 
   # Set up a default endpoint that can be activated with a Director rule
   SilverStripe\GraphQL\Manager.default:


### PR DESCRIPTION
fixing
> PHP Deprecated: Not quoting the scalar "%$SilverStripe\GraphQL\PersistedQuery\GuzzleHTTPClient" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0