### PR TITLE
BUG Add asset-admin test to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,37 @@ language: php
 
 dist: trusty
 
+before_install:
+  - if [[ $BEHAT_TEST ]]; then sudo apt-get update && sudo apt-get install chromium-chromedriver; fi
+
 env:
   global:
-    - COMPOSER_ROOT_VERSION=3.x-dev
+    - COMPOSER_ROOT_VERSION=3.1.x-dev
+    - DISPLAY=":99"
+    - XVFBARGS=":99 -ac -screen 0 1024x768x16"
+    - SS_BASE_URL="http://localhost:8080/"
+    - SS_ENVIRONMENT_TYPE="dev"
+    - BEHAT_RECIPE_CMS_VERSION=4.4.x-dev
+    - ASSET_ADMIN_VERSION=1.4.x-dev
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.1.2
-      env: DB=PGSQL PHPUNIT_TEST=1 PHPCS_TEST=1
-    - php: 7.1.2
-      env: DB=MYSQL PHPUNIT_TEST=1
-    - php: 7.1.2
+    - php: 7.1
       env: DB=MYSQL PDO=1 PHPUNIT_COVERAGE_TEST=1
+    - php: 7.2
+      env: DB=MYSQL PHPUNIT_TEST=1
+    - php: 7.3
+      env: DB=PGSQL PHPUNIT_TEST=1 PHPCS_TEST=1
+    - php: 7.3
+      env: DB=MYSQL BEHAT_TEST=1
+    - php: 7.3
+      env: DB=MYSQL ASSETADMIN_TEST=1
 
 before_script:
+# Extra $PATH
+  - export PATH=/usr/lib/chromium-browser/:$PATH
+
 # Init PHP
   - composer self-update || true
   - phpenv rehash
@@ -24,15 +40,24 @@ before_script:
 
 # Install composer dependencies
   - composer validate
-  - composer install --prefer-dist
-  - composer require --prefer-dist --no-update silverstripe/recipe-core:4.x-dev silverstripe/versioned:1.x-dev silverstripe/assets:1.x-dev --prefer-dist
+  - if [[ ! $BEHAT_TEST ]]; then composer require --prefer-dist --no-update silverstripe/recipe-core:4.x-dev silverstripe/versioned:1.x-dev silverstripe/assets:1.x-dev --prefer-dist ; fi
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.x-dev --prefer-dist --no-update; fi
+  - if [[ $ASSETADMIN_TEST ]]; then composer require silverstripe/asset-admin $ASSET_ADMIN_VERSION --prefer-source --no-update ; fi
+  - if [[ $BEHAT_TEST ]]; then composer require silverstripe/recipe-testing:^1 silverstripe/recipe-cms $BEHAT_RECIPE_CMS_VERSION --prefer-source --no-update ; fi
   - composer update
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.x-dev --prefer-dist; fi
+
+  - if [[ $BEHAT_TEST ]]; then mkdir artifacts; fi
+  - if [[ $BEHAT_TEST ]]; then cp composer.lock artifacts/; fi
+  - if [[ $BEHAT_TEST ]]; then sh -e /etc/init.d/xvfb start; sleep 3; fi
+  - if [[ $BEHAT_TEST ]]; then (chromedriver > artifacts/chromedriver.log 2>&1 &); fi
+  - if [[ $BEHAT_TEST ]]; then (vendor/bin/serve --bootstrap-file vendor/silverstripe/cms/tests/behat/serve-bootstrap.php &> artifacts/serve.log &); fi
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
   - if [[ $PHPCS_TEST ]]; then composer run-script lint; fi
-  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then vendor/bin/phpunit --coverage-clover=coverage.xml; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml -vvv; fi
+  - if [[ $BEHAT_TEST ]]; then vendor/bin/behat @asset-admin --config vendor/silverstripe/asset-admin/behat.yml ; fi
+  - if [[ $ASSETADMIN_TEST ]]; then vendor/bin/phpunit vendor/silverstripe/asset-admin/tests; fi
 
 after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi


### PR DESCRIPTION
This adds the asset-admin tests to the graphql module. Asset-admin is the primary module that relies on graphql, so this serves as a sort of integration test.