### PR TITLE
NEW: Allow instance override of CORS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2369,7 +2369,7 @@ Once you have enabled CORS you can then control four new headers in the HTTP Res
  Allow-Credentials: 'true'
  ```
  
-### Sample Custom CORS Config
+### Apply a CORS config to all GraphQL endpoints
 
 ```yaml
 ## CORS Config
@@ -2382,6 +2382,19 @@ SilverStripe\GraphQL\Controller:
     Allow-Credentials: 'true'
     Max-Age:  600  # 600 seconds = 10 minutes.
 ``` 
+
+### Apply a CORS config to a single GraphQL endpoint
+
+```yaml
+## CORS Config
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\GraphQL\Controller.default
+    properties:
+      corsConfig:
+        Enabled: false
+``` 
+
+
 ## Persisting queries
 
 A common pattern in GraphQL APIs is to store queries on the server by an identifier. This helps save

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -251,7 +251,7 @@ class Controller extends BaseController implements Flushable
     /**
      * @return array
      */
-    public function getCorsConfig()
+    public function getCorsConfig(): array
     {
         return $this->corsConfig;
     }
@@ -259,7 +259,7 @@ class Controller extends BaseController implements Flushable
     /**
      * @return array
      */
-    public function getMergedCorsConfig()
+    public function getMergedCorsConfig(): array
     {
         $defaults = Config::inst()->get(static::class, 'cors');
         $override = $this->corsConfig;

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -45,7 +45,6 @@ class Controller extends BaseController implements Flushable
         'Max-Age' => 86400, // 86,400 seconds = 1 day.
     ];
 
-
     /**
      * If true, store the fragment JSON in a flat file in assets/
      * @var bool

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -45,6 +45,7 @@ class Controller extends BaseController implements Flushable
         'Max-Age' => 86400, // 86,400 seconds = 1 day.
     ];
 
+
     /**
      * If true, store the fragment JSON in a flat file in assets/
      * @var bool
@@ -70,6 +71,12 @@ class Controller extends BaseController implements Flushable
      * @var GeneratedAssetHandler
      */
     protected $assetHandler;
+
+    /**
+     * Override the default cors config per instance
+     * @var array
+     */
+    protected $corsConfig = [];
 
     /**
      * @param Manager $manager
@@ -213,7 +220,7 @@ class Controller extends BaseController implements Flushable
      */
     public function addCorsHeaders(HTTPRequest $request, HTTPResponse $response)
     {
-        $corsConfig = Config::inst()->get(static::class, 'cors');
+        $corsConfig = $this->getMergedCorsConfig();
 
         // If CORS is disabled don't add the extra headers. Simply return the response untouched.
         if (empty($corsConfig['Enabled'])) {
@@ -241,6 +248,36 @@ class Controller extends BaseController implements Flushable
 
         return $response;
     }
+
+    /**
+     * @return array
+     */
+    public function getCorsConfig()
+    {
+        return $this->corsConfig;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMergedCorsConfig()
+    {
+        $defaults = Config::inst()->get(static::class, 'cors');
+        $override = $this->corsConfig;
+
+        return array_merge($defaults, $override);
+    }
+
+    /**
+     * @param array $config
+     * @return $this
+     */
+    public function setCorsConfig(array $config): self
+    {
+        $this->corsConfig = array_merge($this->corsConfig, $config);
+
+        return $this;
+    }    
 
     /**
      * Validate an origin matches a set of allowed origins

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -277,7 +277,7 @@ class Controller extends BaseController implements Flushable
         $this->corsConfig = array_merge($this->corsConfig, $config);
 
         return $this;
-    }    
+    }
 
     /**
      * Validate an origin matches a set of allowed origins

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -389,7 +389,7 @@ class ControllerTest extends SapphireTest
         $this->expectException(HTTPResponse_Exception::class);
         $controller->setCorsConfig(['Enabled' => true]);
         $controller->addCorsHeaders($request, $response);
-    }    
+    }
 
     public function testTypeCaching()
     {

--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -356,6 +356,41 @@ class ControllerTest extends SapphireTest
         $controller->index($request);
     }
 
+    public function testCorsOverride()
+    {
+        Controller::config()->set('cors', [
+            'Enabled' => true,
+            'Allow-Origin' => '*',
+            'Allow-Headers' => 'Authorization, Content-Type',
+            'Allow-Methods' =>  'GET, PUT, OPTIONS',
+            'Allow-Credentials' => '',
+            'Max-Age' => 600
+        ]);
+
+        $controller = new Controller();
+        $this->assertTrue($controller->getMergedCorsConfig()['Enabled']);
+        $this->assertEquals('*', $controller->getMergedCorsConfig()['Allow-Origin']);
+        $controller->setCorsConfig([
+            'Enabled' => false,
+            'Allow-Origin' => 'silverstripe.com',
+        ]);
+        $this->assertFalse($controller->getMergedCorsConfig()['Enabled']);
+        $this->assertEquals('silverstripe.com', $controller->getMergedCorsConfig()['Allow-Origin']);
+
+        $request = new HTTPRequest('GET', '');
+        $request->addHeader('Origin', 'localhost');
+        $response = new HTTPResponse();
+        $response = $controller->addCorsHeaders($request, $response);
+
+        $this->assertTrue($response instanceof HTTPResponse);
+        $this->assertEquals('200', $response->getStatusCode());
+        $this->assertNull($response->getHeader('Access-Control-Allow-Origin'));
+
+        $this->expectException(HTTPResponse_Exception::class);
+        $controller->setCorsConfig(['Enabled' => true]);
+        $controller->addCorsHeaders($request, $response);
+    }    
+
     public function testTypeCaching()
     {
         $expectedSchemaPath = TestAssetStore::base_path() . '/testSchema.types.graphql';


### PR DESCRIPTION
Now that we support multiple schemas, it doesn't make sense that the CORS settings should be global. This allows you to merge in custom settings per instance and is BC with the current static config.

```
SilverStripe\Core\Injector\Injector:
  SilverStripe\GraphQL\Controller.myController:
    properties:
      corsConfig:
        Enabled: false
```