### PR TITLE
Replace deprecated exception assertion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "webonyx/graphql-php": "~0.12.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8",
+        "phpunit/phpunit": "^8 || ^9",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "extra": {

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -135,17 +135,17 @@ class ManagerTest extends SapphireTest
         $this->assertEquals('test', $manager->getSchemaKey());
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/must be a string/');
+        $this->expectExceptionMessageMatches('/must be a string/');
         $manager->setSchemaKey(['test']);
         $this->assertEquals('test', $manager->getSchemaKey());
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/cannnot be empty/');
+        $this->expectExceptionMessageMatches('/cannnot be empty/');
         $manager->setSchemaKey('');
         $this->assertEquals('test', $manager->getSchemaKey());
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/alphanumeric/');
+        $this->expectExceptionMessageMatches('/alphanumeric/');
         $manager->setSchemaKey('completely % invalid #key');
         $this->assertEquals('test', $manager->getSchemaKey());
     }

--- a/tests/Middleware/CSRFMiddlewareTest.php
+++ b/tests/Middleware/CSRFMiddlewareTest.php
@@ -23,7 +23,7 @@ class CSRFMiddlewareTest extends MiddlewareProcessTestBase
     public function testItThrowsIfNoTokenIsProvided()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/must provide a CSRF token/');
+        $this->expectExceptionMessageMatches('/must provide a CSRF token/');
         $result = $this->simulateMiddlewareProcess(
             new CSRFMiddleware(),
             ' mutation someMutation { tester }'
@@ -69,7 +69,7 @@ GRAPHQL;
     public function testItThrowsIfTokenIsInvalid()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/Invalid CSRF token/');
+        $this->expectExceptionMessageMatches('/Invalid CSRF token/');
         $result = $this->simulateMiddlewareProcess(
             new CSRFMiddleware(),
             ' mutation someMutation { tester }',

--- a/tests/Middleware/HTTPMethodMiddlewareTest.php
+++ b/tests/Middleware/HTTPMethodMiddlewareTest.php
@@ -24,7 +24,7 @@ class HTTPMethodMiddlewareTest extends MiddlewareProcessTestBase
     public function testItThrowsIfNotPOSTorGET()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/must be POST or GET/');
+        $this->expectExceptionMessageMatches('/must be POST or GET/');
         $result = $this->simulateMiddlewareProcess(
             new HTTPMethodMiddleware(),
             ' query someQuery { tester }',
@@ -36,7 +36,7 @@ class HTTPMethodMiddlewareTest extends MiddlewareProcessTestBase
     public function testItThrowsIfMutationIsNotPOST()
     {
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/Mutations must use the POST/');
+        $this->expectExceptionMessageMatches('/Mutations must use the POST/');
         $result = $this->simulateMiddlewareProcess(
             new HTTPMethodMiddleware(),
             ' mutation someMutation { tester }',

--- a/tests/Scaffolding/Scaffolders/CRUD/CreateTest.php
+++ b/tests/Scaffolding/Scaffolders/CRUD/CreateTest.php
@@ -142,7 +142,7 @@ class CreateTest extends SapphireTest
         $scaffold = $create->scaffold($manager);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/Cannot create/');
+        $this->expectExceptionMessageMatches('/Cannot create/');
 
         $scaffold['resolve'](
             null,

--- a/tests/Scaffolding/Scaffolders/CRUD/DeleteTest.php
+++ b/tests/Scaffolding/Scaffolders/CRUD/DeleteTest.php
@@ -124,7 +124,7 @@ class DeleteTest extends SapphireTest
         $scaffold = $delete->scaffold($manager);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/Cannot delete/');
+        $this->expectExceptionMessageMatches('/Cannot delete/');
 
         $scaffold['resolve'](
             $restrictedDataobject,

--- a/tests/Scaffolding/Scaffolders/CRUD/UpdateTest.php
+++ b/tests/Scaffolding/Scaffolders/CRUD/UpdateTest.php
@@ -138,7 +138,7 @@ class UpdateTest extends SapphireTest
         $scaffold = $update->scaffold($manager);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/Cannot edit/');
+        $this->expectExceptionMessageMatches('/Cannot edit/');
 
         $scaffold['resolve'](
             $restrictedDataobject,

--- a/tests/Scaffolding/Scaffolders/DataObjectScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/DataObjectScaffolderTest.php
@@ -41,7 +41,7 @@ class DataObjectScaffolderTest extends SapphireTest
         $this->assertInstanceOf(DataObjectFake::class, $scaffolder->getDataObjectInstance());
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Non-existent classname/i');
+        $this->expectExceptionMessageMatches('/Non-existent classname/i');
         new DataObjectScaffolder('fail');
     }
 
@@ -138,7 +138,7 @@ class DataObjectScaffolderTest extends SapphireTest
         $this->assertEquals(1, $scaffolder->getOperations()->count());
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Invalid operation/');
+        $this->expectExceptionMessageMatches('/Invalid operation/');
         $scaffolder = $this->getFakeScaffolder();
         $scaffolder->operation('fail');
     }
@@ -173,7 +173,7 @@ class DataObjectScaffolderTest extends SapphireTest
 
         // Can't add a nested query for a regular field
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/returns a DataList or ArrayList/');
+        $this->expectExceptionMessageMatches('/returns a DataList or ArrayList/');
         $scaffolder = $this->getFakeScaffolder();
         $scaffolder->nestedQuery('MyField');
     }
@@ -270,7 +270,7 @@ class DataObjectScaffolderTest extends SapphireTest
 
         // Must have "fields" defined
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/^No fields or nestedQueries/');
+        $this->expectExceptionMessageMatches('/^No fields or nestedQueries/');
         $scaffolder->applyConfig([
             'operations' => ['create' => true],
         ]);
@@ -282,7 +282,7 @@ class DataObjectScaffolderTest extends SapphireTest
 
         // Invalid fields
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/Fields must be an array/');
+        $this->expectExceptionMessageMatches('/Fields must be an array/');
         $scaffolder->applyConfig([
             'fields' => 'fail',
         ]);
@@ -294,7 +294,7 @@ class DataObjectScaffolderTest extends SapphireTest
 
         // Invalid fieldsExcept
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/"excludeFields" must be an enumerated list/');
+        $this->expectExceptionMessageMatches('/"excludeFields" must be an enumerated list/');
         $scaffolder->applyConfig([
             'fields' => ['MyField'],
             'excludeFields' => 'fail',
@@ -307,7 +307,7 @@ class DataObjectScaffolderTest extends SapphireTest
 
         // Invalid operations
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/Operations field must be a map/');
+        $this->expectExceptionMessageMatches('/Operations field must be a map/');
         $scaffolder->applyConfig([
             'fields' => ['MyField'],
             'operations' => ['create'],
@@ -320,7 +320,7 @@ class DataObjectScaffolderTest extends SapphireTest
 
         // Invalid nested queries
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/"nestedQueries" must be a map of relation name/');
+        $this->expectExceptionMessageMatches('/"nestedQueries" must be a map of relation name/');
         $scaffolder->applyConfig([
             'fields' => ['MyField'],
             'nestedQueries' => ['Files'],
@@ -373,7 +373,7 @@ class DataObjectScaffolderTest extends SapphireTest
     public function testDataObjectScaffolderScaffoldFieldException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Invalid field/');
+        $this->expectExceptionMessageMatches('/Invalid field/');
         $scaffolder = $this->getFakeScaffolder()
             ->addFields(['not a field'])
             ->scaffold(new Manager());
@@ -383,7 +383,7 @@ class DataObjectScaffolderTest extends SapphireTest
     public function testDataObjectScaffolderScaffoldNestedQueryException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/returns a list/');
+        $this->expectExceptionMessageMatches('/returns a list/');
         $scaffolder = $this->getFakeScaffolder()
             ->addFields(['Files'])
             ->scaffold(new Manager());

--- a/tests/Scaffolding/Scaffolders/InheritanceScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/InheritanceScaffolderTest.php
@@ -19,7 +19,7 @@ class InheritanceScaffolderTest extends SapphireTest
     public function testThrowsOnNonExistentClass()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/not exist/');
+        $this->expectExceptionMessageMatches('/not exist/');
 
         $scaffolder = new InheritanceScaffolder('fail');
     }
@@ -27,7 +27,7 @@ class InheritanceScaffolderTest extends SapphireTest
     public function testThrowsOnNonDataObjectClass()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/subclass of/');
+        $this->expectExceptionMessageMatches('/subclass of/');
 
         $scaffolder = new InheritanceScaffolder(Controller::class);
     }

--- a/tests/Scaffolding/Scaffolders/ListQueryScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/ListQueryScaffolderTest.php
@@ -163,7 +163,7 @@ class ListQueryScaffolderTest extends SapphireTest
     public function testListQueryScaffolderApplyConfigThrowsOnBadSortableFields()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/sortableFields must be an array/');
+        $this->expectExceptionMessageMatches('/sortableFields must be an array/');
         $scaffolder = new ListQueryScaffolder('testQuery', 'testType');
         $scaffolder->applyConfig([
             'sortableFields' => 'fail',

--- a/tests/Scaffolding/Scaffolders/OperationScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/OperationScaffolderTest.php
@@ -170,7 +170,7 @@ class OperationScaffolderTest extends SapphireTest
         $this->assertTrue($success);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/closures, instances of/');
+        $this->expectExceptionMessageMatches('/closures, instances of/');
         $scaffolder->setResolver('fail');
     }
 

--- a/tests/Scaffolding/Scaffolders/SchemaScaffolderTest.php
+++ b/tests/Scaffolding/Scaffolders/SchemaScaffolderTest.php
@@ -179,7 +179,7 @@ class SchemaScaffolderTest extends SapphireTest
     public function testSchemaScaffolderCreateFromConfigThrowsIfBadTypes()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/"types" must be a map of class name to settings/');
+        $this->expectExceptionMessageMatches('/"types" must be a map of class name to settings/');
         SchemaScaffolder::createFromConfig([
             'types' => ['fail'],
         ]);
@@ -188,7 +188,7 @@ class SchemaScaffolderTest extends SapphireTest
     public function testSchemaScaffolderCreateFromConfigThrowsIfBadQueries()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/must be a map of operation name to settings/');
+        $this->expectExceptionMessageMatches('/must be a map of operation name to settings/');
         SchemaScaffolder::createFromConfig([
             'types' => [
                 DataObjectFake::class => [
@@ -259,7 +259,7 @@ class SchemaScaffolderTest extends SapphireTest
     {
         Config::modify()->merge(SchemaScaffolder::class, 'fixed_types', ['stdclass']);
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/Cannot auto register/');
+        $this->expectExceptionMessageMatches('/Cannot auto register/');
         (new SchemaScaffolder())->addToManager(new Manager());
     }
 
@@ -267,7 +267,7 @@ class SchemaScaffolderTest extends SapphireTest
     {
         Config::modify()->merge(SchemaScaffolder::class, 'fixed_types', [ArrayList::class]);
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/Cannot auto register/');
+        $this->expectExceptionMessageMatches('/Cannot auto register/');
         (new SchemaScaffolder())->addToManager(new Manager());
     }
 
@@ -275,7 +275,7 @@ class SchemaScaffolderTest extends SapphireTest
     {
         Config::modify()->merge(SchemaScaffolder::class, 'fixed_types', 'fail');
         $this->expectException(Exception::class);
-        $this->expectExceptionMessageRegExp('/must be an array/');
+        $this->expectExceptionMessageMatches('/must be an array/');
         (new SchemaScaffolder())->addToManager(new Manager());
     }
 

--- a/tests/Scaffolding/StaticSchemaTest.php
+++ b/tests/Scaffolding/StaticSchemaTest.php
@@ -141,12 +141,12 @@ class StaticSchemaTest extends SapphireTest
         $this->assertSame($result, $singleType);
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/illegal mode/');
+        $this->expectExceptionMessageMatches('/illegal mode/');
         StaticSchema::inst()
             ->fetchFromManager(FakeSiteTree::class, $manager, 'fail');
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/could not be resolved/');
+        $this->expectExceptionMessageMatches('/could not be resolved/');
         StaticSchema::inst()
             ->fetchFromManager('fail', $manager);
     }

--- a/tests/Scaffolding/Util/ArrayTypeParserTest.php
+++ b/tests/Scaffolding/Util/ArrayTypeParserTest.php
@@ -41,14 +41,14 @@ class ArrayTypeParserTest extends SapphireTest
     public function testInvalidConstructorNotArray()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/second parameter must be an associative array/');
+        $this->expectExceptionMessageMatches('/second parameter must be an associative array/');
         new ArrayTypeParser('test', 'String');
     }
 
     public function testInvalidConstructorNotAssociative()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/second parameter must be an associative array/');
+        $this->expectExceptionMessageMatches('/second parameter must be an associative array/');
         new ArrayTypeParser('test', ['oranges', 'apples']);
     }
 }

--- a/tests/Scaffolding/Util/OperationListTest.php
+++ b/tests/Scaffolding/Util/OperationListTest.php
@@ -29,7 +29,7 @@ class OperationListTest extends SapphireTest
         $this->assertEquals(1, $list->count());
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/only accepts instances of/');
+        $this->expectExceptionMessageMatches('/only accepts instances of/');
         $list->push(new OperationList());
     }
 }

--- a/tests/Scaffolding/Util/StringTypeParserTest.php
+++ b/tests/Scaffolding/Util/StringTypeParserTest.php
@@ -55,14 +55,14 @@ class StringTypeParserTest extends SapphireTest
     public function testTypeInvalid()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/Invalid argument/');
+        $this->expectExceptionMessageMatches('/Invalid argument/');
         new StringTypeParser('  ... Nothing');
     }
 
     public function testTypeNotAString()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessageRegExp('/must be passed a string/');
+        $this->expectExceptionMessageMatches('/must be passed a string/');
         new StringTypeParser(['fail']);
     }
 


### PR DESCRIPTION
`expectExceptionMessageRegExp` is being deprecated in favour of `expectExceptionMessageMatches`