### PR TITLE
MINOR: add result to onAfterMiddlware hook

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -143,7 +143,7 @@ class Manager implements ConfigurationApplier
 
         $result = $next($schema, $query, $context, $params);
 
-        $this->extend('onAfterCallMiddleware', $schema, $query, $context, $params);
+        $this->extend('onAfterCallMiddleware', $schema, $query, $context, $params, $result);
 
         return $result;
     }


### PR DESCRIPTION
Needed for snapshots, and seems like it could be useful in other contexts.