### PR TITLE
BUG Require frameworktest for behat test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION=3.6.x-dev
+    - COMPOSER_ROOT_VERSION=3.3.x-dev
     - SS_BASE_URL="http://localhost:8080/"
     - SS_ENVIRONMENT_TYPE="dev"
     - RECIPE_CMS_VERSION=4.6.x-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_script:
   - if [[ (! $BEHAT_TEST) && (! $ASSETADMIN_TEST) ]]; then composer require --prefer-dist --no-update silverstripe/recipe-core:4.x-dev silverstripe/versioned:1.x-dev silverstripe/assets:1.x-dev --prefer-dist ; fi
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.x-dev --prefer-dist --no-update; fi
   - if [[ $ASSETADMIN_TEST ]]; then composer require silverstripe/recipe-cms $RECIPE_CMS_VERSION --prefer-source --no-update ; fi
-  - if [[ $BEHAT_TEST ]]; then composer require silverstripe/recipe-testing:^1 silverstripe/recipe-cms $RECIPE_CMS_VERSION --prefer-source --no-update ; fi
+  - if [[ $BEHAT_TEST ]]; then composer require silverstripe/recipe-testing:^1 silverstripe/recipe-cms $RECIPE_CMS_VERSION silverstripe/frameworktest:^0.1.0 --prefer-source --no-update ; fi
   - composer update
 
   - if [[ $BEHAT_TEST ]]; then mkdir artifacts; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ install:
 
 env:
   global:
-    - COMPOSER_ROOT_VERSION=3.x-dev
+    - COMPOSER_ROOT_VERSION=3.6.x-dev
     - SS_BASE_URL="http://localhost:8080/"
     - SS_ENVIRONMENT_TYPE="dev"
-    - RECIPE_CMS_VERSION=4.x-dev
+    - RECIPE_CMS_VERSION=4.6.x-dev
 
 matrix:
   fast_finish: true
@@ -51,7 +51,7 @@ before_script:
 
 # Install composer dependencies
   - composer validate
-  - if [[ (! $BEHAT_TEST) && (! $ASSETADMIN_TEST) ]]; then composer require --prefer-dist --no-update silverstripe/recipe-core:4.x-dev silverstripe/versioned:1.x-dev silverstripe/assets:1.x-dev --prefer-dist ; fi
+  - if [[ (! $BEHAT_TEST) && (! $ASSETADMIN_TEST) ]]; then composer require --prefer-dist --no-update silverstripe/recipe-core:4.6.x-dev silverstripe/versioned:1.6.x-dev silverstripe/assets:1.6.x-dev --prefer-dist ; fi
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.x-dev --prefer-dist --no-update; fi
   - if [[ $ASSETADMIN_TEST ]]; then composer require silverstripe/recipe-cms $RECIPE_CMS_VERSION --prefer-source --no-update ; fi
   - if [[ $BEHAT_TEST ]]; then composer require silverstripe/recipe-testing:^1 silverstripe/recipe-cms $RECIPE_CMS_VERSION silverstripe/frameworktest:^0.1.0 --prefer-source --no-update ; fi


### PR DESCRIPTION
The asset-admin behat test now requires frameworktest to work because of https://github.com/silverstripe/silverstripe-asset-admin/pull/1038