### PR TITLE
Make silverstripe-graphql independent of the presence of Versioned mo…

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -103,10 +103,13 @@ class Controller extends BaseController implements Flushable
      */
     public function index(HTTPRequest $request)
     {
-        $stage = $request->param('Stage');
-        if ($stage && in_array($stage, [Versioned::DRAFT, Versioned::LIVE])) {
-            Versioned::set_stage($stage);
+        if (class_exists(Versioned::class)) {
+            $stage = $request->param('Stage');
+            if ($stage && in_array($stage, [Versioned::DRAFT, Versioned::LIVE])) {
+                Versioned::set_stage($stage);
+            }
         }
+        
         // Check for a possible CORS preflight request and handle if necessary
         // Refer issue 66:  https://github.com/silverstripe/silverstripe-graphql/issues/66
         if ($request->httpMethod() === 'OPTIONS') {


### PR DESCRIPTION
silverstripe-graphql index() function calls a Versioned methods and this makes it impossible to have the silverstripe-graphql module installed without the Versioned module.

I think that it could be usefull to install it without the Versioned module.

Please, could you also introduce in the index() function the verification of the presence of the Versioned class in order to install the silverstripe-graphql module without the Versioned module?

Like in the file commit, for example.
Thank you.