### PR TITLE
PoC: Move persisted request processing to injectable class

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,7 +3,6 @@ Name: graphqlconfig
 ---
 # Define the type parsers
 SilverStripe\Core\Injector\Injector:
-
   SilverStripe\GraphQL\QueryHandler\QueryHandlerInterface:
     class: SilverStripe\GraphQL\QueryHandler\QueryHandler
 
@@ -15,6 +14,9 @@ SilverStripe\Core\Injector\Injector:
 
   SilverStripe\GraphQL\PersistedQuery\PersistedQueryMappingProvider:
     class: SilverStripe\GraphQL\PersistedQuery\JSONStringProvider
+
+  SilverStripe\GraphQL\PersistedQuery\RequestProcessor:
+    class: SilverStripe\GraphQL\PersistedQuery\RequestIDProcessor
 
   SilverStripe\GraphQL\PersistedQuery\HTTPProvider:
     constructor:

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\GraphQL;
 
 use Exception;
+use InvalidArgumentException;
 use LogicException;
 use SilverStripe\Assets\Storage\GeneratedAssetHandler;
 use SilverStripe\Control\Controller as BaseController;
@@ -18,6 +19,7 @@ use SilverStripe\GraphQL\Dev\Benchmark;
 use SilverStripe\GraphQL\Dev\Build;
 use SilverStripe\GraphQL\Dev\State\DisableTypeCacheState;
 use SilverStripe\GraphQL\Permission\MemberContextProvider;
+use SilverStripe\GraphQL\PersistedQuery\RequestProcessor;
 use SilverStripe\GraphQL\QueryHandler\QueryHandlerInterface;
 use SilverStripe\GraphQL\Schema\Exception\SchemaNotFoundException;
 use SilverStripe\GraphQL\Schema\Interfaces\ContextProvider;
@@ -26,7 +28,6 @@ use SilverStripe\ORM\Connect\DatabaseException;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Versioned\Versioned;
-use InvalidArgumentException;
 
 /**
  * Top level controller for handling graphql requests.
@@ -423,16 +424,9 @@ class Controller extends BaseController implements Flushable
             $id = isset($data['id']) ? $data['id'] : null;
             $variables = isset($data['variables']) ? (array)$data['variables'] : null;
         } else {
-            $query = $request->requestVar('query');
-            $id = $request->requestVar('id');
-            $variables = json_decode($request->requestVar('variables'), true);
-        }
-
-        if ($id) {
-            if ($query) {
-                throw new LogicException('Cannot pass a query when an ID has been specified.');
-            }
-            $query = $this->manager->getQueryFromPersistedID($id);
+            /** @var RequestProcessor $persistedProcessor  */
+            $persistedProcessor = Injector::inst()->get(RequestProcessor::class);
+            list($query, $variables) = $persistedProcessor->getRequestQueryVariables($request);
         }
 
         return [$query, $variables];

--- a/src/PersistedQuery/RequestIDProcessor.php
+++ b/src/PersistedQuery/RequestIDProcessor.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SilverStripe\GraphQL\PersistedQuery;
+
+use LogicException;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\GraphQL\PersistedQuery\PersistedQueryMappingProvider;
+
+class RequestIDProcessor implements RequestProcessor
+{
+    /**
+     * Parse query and variables from the given request
+     *
+     * @param HTTPRequest $request
+     * @return array Array containing query and variables as a pair
+     * @throws LogicException
+     */
+    public function getRequestQueryVariables(HTTPRequest $request): array
+    {
+        $query = $request->requestVar('query');
+        $id = $request->requestVar('id');
+        $variables = json_decode($request->requestVar('variables'), true);
+
+        if ($id) {
+            if ($query) {
+                throw new LogicException('Cannot pass a query when an ID has been specified.');
+            }
+            /** @var PersistedQueryMappingProvider $provider */
+            $provider = Injector::inst()->get(PersistedQueryMappingProvider::class);
+
+            $query = $provider->getByID($id);
+        }
+
+        return [$query, $variables];
+    }
+}

--- a/src/PersistedQuery/RequestProcessor.php
+++ b/src/PersistedQuery/RequestProcessor.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\PersistedQuery;
+
+use SilverStripe\Control\HTTPRequest;
+
+/**
+ * Implementations of query persistence must use this interface. At a minimum, they
+ * must be able to fetch a query given an ID.
+ */
+interface RequestProcessor
+{
+    /**
+     * @param string $id
+     * @return string|null
+     */
+    /**
+     * Parse query and variables from the given request
+     *
+     * @param HTTPRequest $request
+     * @return array Array containing query and variables as a pair
+     */
+    public function getRequestQueryVariables(HTTPRequest $request): array;
+}


### PR DESCRIPTION
This is only an idea that I'd like to develop further but looking for a bit of feedback on approach.

the motivation comes from setting up https://github.com/apollographql/apollo-link-persisted-queries which seems to be a common client library to use for persisted queries. Currently, Controller.php expects any GET request with a persisted query ID to supply that as a query param named `id`. By default apollo-link-persisted-queries has a different structure (a param that looks like `&extensions={"persistedQuery":{"version":1,"sha256Hash":"e2d83966...`) 

so the thought is to move the extraction of the query ID (and probably fetching the query from ID too) into an Injectable class so that different implementations can more easily created/added. 

If this looks reasonable I can also move the default query/variable logic into a similar class and add one to support apollo-link-persisted-queries