### PR TITLE
NEW: field formatting API (GraphQL 4 foward compat)

### DIFF
--- a/src/FieldAccessorInterface.php
+++ b/src/FieldAccessorInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace SilverStripe\GraphQL;
+
+use SilverStripe\View\ViewableData;
+
+interface FieldAccessorInterface
+{
+    /**
+     * @param ViewableData $object
+     * @param $fieldName
+     * @param array $opts
+     * @param bool $asObject
+     * @return mixed
+     */
+    public function getValue(ViewableData $object, $fieldName, $opts = [], $asObject = false);
+
+    /**
+     * @param ViewableData $object
+     * @param $fieldName
+     * @param $value
+     * @param array $opts
+     * @return mixed
+     */
+    public function setValue(ViewableData $object, $fieldName, $value, $opts = []);
+
+    /**
+     * @param ViewableData $object
+     * @param $fieldName
+     * @param array $opts
+     * @return mixed
+     */
+    public function getObjectFieldName(ViewableData $object, $fieldName, $opts = []);
+}

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -204,12 +204,18 @@ class Manager implements ConfigurationApplier
         $this->extend('updateConfig', $config);
 
         // Bootstrap schema class mapping from config
-        if ($config && array_key_exists('typeNames', $config)) {
+        if (array_key_exists('typeNames', $config)) {
             StaticSchema::inst()->setTypeNames($config['typeNames']);
+        }
+        if (array_key_exists('fieldFormatter', $config)) {
+            StaticSchema::inst()->setFieldFormatter($config['fieldFormatter']);
+        }
+        if (array_key_exists('fieldAccessor', $config)) {
+            StaticSchema::inst()->setFieldAccessor(Injector::inst()->get($config['fieldAccessor']));
         }
 
         // Types (incl. Interfaces and InputTypes)
-        if ($config && array_key_exists('types', $config)) {
+        if (array_key_exists('types', $config)) {
             foreach ($config['types'] as $name => $typeCreatorClass) {
                 $typeCreator = Injector::inst()->create($typeCreatorClass, $this);
                 if (!($typeCreator instanceof TypeCreator)) {

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -19,6 +19,7 @@ use SilverStripe\GraphQL\Scaffolding\Interfaces\ConfigurationApplier;
 use SilverStripe\GraphQL\PersistedQuery\PersistedQueryMappingProvider;
 use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\GraphQL\Middleware\QueryMiddleware;
+use SilverStripe\GraphQL\Util\NaiveFieldAccessor;
 use SilverStripe\ORM\ValidationException;
 use SilverStripe\Security\Member;
 use SilverStripe\GraphQL\Scaffolding\Interfaces\ScaffoldingProvider;
@@ -212,6 +213,8 @@ class Manager implements ConfigurationApplier
         }
         if (array_key_exists('fieldAccessor', $config)) {
             StaticSchema::inst()->setFieldAccessor(Injector::inst()->get($config['fieldAccessor']));
+        } else {
+            StaticSchema::inst()->setFieldAccessor(Injector::inst()->get(NaiveFieldAccessor::class));
         }
 
         // Types (incl. Interfaces and InputTypes)

--- a/src/Pagination/Connection.php
+++ b/src/Pagination/Connection.php
@@ -291,6 +291,10 @@ class Connection implements OperationResolver
             'edges' => [
                 'type' => Type::listOf($this->getEdgeType()),
                 'description' => 'Collection of records'
+            ],
+            'nodes' => [
+                'type' => Type::listOf($this->getConnectionType()),
+                'description' => 'The node at the end of the collections edge',
             ]
         ];
     }
@@ -410,11 +414,12 @@ class Connection implements OperationResolver
 
         return [
             'edges'    => $list,
+            'nodes'    => $list,
             'pageInfo' => [
                 'totalCount'      => $count,
                 'hasNextPage'     => $nextPage,
                 'hasPreviousPage' => $previousPage
-            ]
+            ],
         ];
     }
 

--- a/src/Scaffolding/Scaffolders/CRUD/Create.php
+++ b/src/Scaffolding/Scaffolders/CRUD/Create.php
@@ -12,6 +12,7 @@ use SilverStripe\GraphQL\OperationResolver;
 use SilverStripe\GraphQL\Scaffolding\Extensions\TypeCreatorExtension;
 use SilverStripe\GraphQL\Scaffolding\Interfaces\CRUDInterface;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\MutationScaffolder;
+use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectSchema;
 use SilverStripe\ORM\FieldType\DBField;
@@ -59,8 +60,9 @@ class Create extends MutationScaffolder implements OperationResolver, CRUDInterf
      */
     protected function createDefaultArgs(Manager $manager)
     {
+        $argName = $this->argName();
         return [
-            'Input' => [
+            $argName => [
                 'type' => Type::nonNull($manager->getType($this->inputTypeName())),
             ]
         ];
@@ -120,7 +122,7 @@ class Create extends MutationScaffolder implements OperationResolver, CRUDInterf
 
         /** @var DataObject $newObject */
         $newObject = Injector::inst()->create($this->getDataObjectClass());
-        $newObject->update($args['Input']);
+        $newObject->update($args[$this->argName()]);
 
         // Extension points that return false should kill the create
         $results = $this->extend('augmentMutation', $newObject, $args, $context, $info);
@@ -135,5 +137,13 @@ class Create extends MutationScaffolder implements OperationResolver, CRUDInterf
         $this->extend('afterMutation', $newObject, $args, $context, $info);
 
         return $newObject;
+    }
+
+    /**
+     * @return string
+     */
+    private function argName()
+    {
+        return StaticSchema::inst()->formatField('Input');
     }
 }

--- a/src/Scaffolding/Scaffolders/CRUD/Read.php
+++ b/src/Scaffolding/Scaffolders/CRUD/Read.php
@@ -12,6 +12,7 @@ use SilverStripe\GraphQL\QueryFilter\QueryFilterAware;
 use SilverStripe\GraphQL\Scaffolding\Interfaces\CRUDInterface;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\ListQueryScaffolder;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
+use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObjectInterface;
 use SilverStripe\Security\Member;
@@ -37,8 +38,8 @@ class Read extends ListQueryScaffolder implements OperationResolver, CRUDInterfa
     {
         parent::__construct(null, null, $this, $dataObjectClass);
         $filter = Injector::inst()->create(DataObjectQueryFilter::class, $dataObjectClass)
-            ->setFilterKey(self::FILTER)
-            ->setExcludeKey(self::EXCLUDE);
+            ->setFilterKey(StaticSchema::inst()->formatField(self::FILTER))
+            ->setExcludeKey(StaticSchema::inst()->formatField(self::EXCLUDE));
         $this->setQueryFilter($filter);
     }
 
@@ -131,11 +132,14 @@ class Read extends ListQueryScaffolder implements OperationResolver, CRUDInterfa
         if (!$this->queryFilter->exists()) {
             return [];
         }
+        $filterKey = StaticSchema::inst()->formatField(self::FILTER);
+        $excludeKey = StaticSchema::inst()->formatField(self::EXCLUDE);
+
         return [
-            self::FILTER => [
+            $filterKey => [
                 'type' => $manager->getType($this->inputTypeName(self::FILTER)),
             ],
-            self::EXCLUDE => [
+            $excludeKey => [
                 'type' => $manager->getType($this->inputTypeName(self::EXCLUDE)),
             ],
         ];

--- a/src/Scaffolding/Scaffolders/CRUD/ReadOne.php
+++ b/src/Scaffolding/Scaffolders/CRUD/ReadOne.php
@@ -13,6 +13,7 @@ use SilverStripe\GraphQL\QueryFilter\QueryFilterAware;
 use SilverStripe\GraphQL\Scaffolding\Interfaces\CRUDInterface;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\ItemQueryScaffolder;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder;
+use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObjectInterface;
 use InvalidArgumentException;
@@ -33,8 +34,8 @@ class ReadOne extends ItemQueryScaffolder implements OperationResolver, CRUDInte
     {
         parent::__construct(null, null, $this, $dataObjectClass);
         $filter = Injector::inst()->create(DataObjectQueryFilter::class, $dataObjectClass)
-            ->setFilterKey(Read::FILTER)
-            ->setExcludeKey(Read::EXCLUDE);
+            ->setFilterKey(StaticSchema::inst()->formatField(Read::FILTER))
+            ->setExcludeKey(StaticSchema::inst()->formatField(Read::EXCLUDE));
         $this->setQueryFilter($filter);
     }
 
@@ -54,17 +55,19 @@ class ReadOne extends ItemQueryScaffolder implements OperationResolver, CRUDInte
      */
     protected function createDefaultArgs(Manager $manager)
     {
+        $id = StaticSchema::inst()->formatField('ID');
         $args = [
-            'ID' => [
+            $id => [
                 'type' => Type::id()
             ],
         ];
-
+        $filterKey = StaticSchema::inst()->formatField(Read::FILTER);
+        $excludeKey = StaticSchema::inst()->formatField(Read::EXCLUDE);
         if ($this->queryFilter->exists()) {
-            $args[Read::FILTER] = [
+            $args[$filterKey] = [
                 'type' => $this->queryFilter->getInputType($this->inputTypeName(Read::FILTER)),
             ];
-            $args[Read::EXCLUDE] = [
+            $args[$excludeKey] = [
                 'type' => $this->queryFilter->getInputType($this->inputTypeName(Read::EXCLUDE)),
             ];
         }
@@ -91,10 +94,11 @@ class ReadOne extends ItemQueryScaffolder implements OperationResolver, CRUDInte
      */
     public function resolve($object, array $args, $context, ResolveInfo $info)
     {
+        $id = StaticSchema::inst()->formatField('ID');
         // get as a list so extensions can influence it pre-query
         $list = DataList::create($this->getDataObjectClass());
-        if (isset($args['ID'])) {
-            $list = $list->filter('ID', $args['ID']);
+        if (isset($args[$id])) {
+            $list = $list->filter('ID', $args[$id]);
         }
         if ($this->queryFilter->exists()) {
             $list = $this->queryFilter->applyArgsToList($list, $args);

--- a/src/Scaffolding/Scaffolders/CRUD/Update.php
+++ b/src/Scaffolding/Scaffolders/CRUD/Update.php
@@ -12,6 +12,7 @@ use SilverStripe\GraphQL\OperationResolver;
 use SilverStripe\GraphQL\Scaffolding\Extensions\TypeCreatorExtension;
 use SilverStripe\GraphQL\Scaffolding\Interfaces\CRUDInterface;
 use SilverStripe\GraphQL\Scaffolding\Scaffolders\MutationScaffolder;
+use SilverStripe\GraphQL\Scaffolding\StaticSchema;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObjectInterface;
 use SilverStripe\ORM\DataObjectSchema;
@@ -62,8 +63,9 @@ class Update extends MutationScaffolder implements OperationResolver, CRUDInterf
      */
     protected function createDefaultArgs(Manager $manager)
     {
+        $input = $this->argName();
         return [
-            'Input' => [
+            $input => [
                 'type' => Type::nonNull($manager->getType($this->inputTypeName())),
             ],
         ];
@@ -127,7 +129,8 @@ class Update extends MutationScaffolder implements OperationResolver, CRUDInterf
      */
     public function resolve($object, array $args, $context, ResolveInfo $info)
     {
-        $input = $args['Input'];
+        $input = $this->argName();
+        $input = $args[$input];
         $obj = DataList::create($this->getDataObjectClass())
             ->byID($input['ID']);
         if (!$obj) {
@@ -157,5 +160,13 @@ class Update extends MutationScaffolder implements OperationResolver, CRUDInterf
         $this->extend('afterMutation', $obj, $args, $context, $info);
 
         return $obj;
+    }
+
+    /**
+     * @return string
+     */
+    private function argName()
+    {
+        return StaticSchema::inst()->formatField('Input');
     }
 }

--- a/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
+++ b/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
@@ -341,7 +341,7 @@ class DataObjectScaffolder implements ManagerMutatorInterface, ScaffolderInterfa
 
         if (!$queryScaffolder) {
             // If no scaffolder if provided, try to infer the type by resolving the field
-            $result = $this->getDataObjectInstance()->obj($fieldName);
+            $result = StaticSchema::inst()->accessField($this->getDataObjectInstance(), $fieldName);
 
             if (!$result instanceof DataList && !$result instanceof ArrayList) {
                 throw new InvalidArgumentException(
@@ -352,14 +352,13 @@ class DataObjectScaffolder implements ManagerMutatorInterface, ScaffolderInterfa
                     )
                 );
             }
-
             $queryScaffolder = Injector::inst()->create(
                 ListQueryScaffolder::class,
                 $fieldName,
                 null,
                 function ($obj) use ($fieldName) {
                     /* @var DataObject $obj */
-                    return $obj->obj($fieldName);
+                    return StaticSchema::inst()->accessField($obj, $fieldName);
                 },
                 $result->dataClass()
             );
@@ -669,7 +668,7 @@ class DataObjectScaffolder implements ManagerMutatorInterface, ScaffolderInterfa
             /**
              * @var DataObject $obj
              */
-            $field = $obj->obj($info->fieldName);
+            $field = StaticSchema::inst()->accessField($obj, $info->fieldName);
             // return the raw field value, or checks like `is_numeric()` fail
             if ($field instanceof DBField && $field->isInternalGraphQLType()) {
                 return $field->getValue();
@@ -689,7 +688,7 @@ class DataObjectScaffolder implements ManagerMutatorInterface, ScaffolderInterfa
                 );
             }
 
-            $result = $instance->obj($fieldName);
+            $result = StaticSchema::inst()->accessField($instance, $fieldName);
 
             if ($result instanceof SS_List) {
                 throw new InvalidArgumentException(
@@ -722,10 +721,10 @@ class DataObjectScaffolder implements ManagerMutatorInterface, ScaffolderInterfa
 
         foreach ($this->nestedQueries as $name => $scaffolder) {
             $scaffold = $scaffolder->scaffold($manager);
-            $scaffold['name'] = $name;
+            $scaffold['name'] = StaticSchema::inst()->formatField($name);
             $fieldMap[$name] = $scaffold;
         }
 
-        return $fieldMap;
+        return StaticSchema::inst()->formatKeys($fieldMap);
     }
 }

--- a/src/Util/CaseInsensitiveFieldAccessor.php
+++ b/src/Util/CaseInsensitiveFieldAccessor.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\GraphQL\Util;
 
+use SilverStripe\GraphQL\FieldAccessorInterface;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\View\ViewableData;
@@ -21,7 +22,7 @@ use InvalidArgumentException;
  * @see http://www.php.net/manual/en/functions.user-defined.php
  * @see http://php.net/manual/en/function.array-change-key-case.php
  */
-class CaseInsensitiveFieldAccessor
+class CaseInsensitiveFieldAccessor implements FieldAccessorInterface
 {
 
     const HAS_METHOD = 'HAS_METHOD';
@@ -34,9 +35,10 @@ class CaseInsensitiveFieldAccessor
      * @param string $fieldName Name of the field/getter/method
      * @param array $opts Map of which lookups to use (class constants to booleans).
      *              Example: [ViewableDataCaseInsensitiveFieldMapper::HAS_METHOD => true]
+     * @param bool $asObject If true, return the DBField instance instead of the scalar value.
      * @return mixed
      */
-    public function getValue(ViewableData $object, $fieldName, $opts = [])
+    public function getValue(ViewableData $object, $fieldName, $opts = [], $asObject = false)
     {
         $opts = $opts ?: [];
         $opts = array_merge([
@@ -63,7 +65,7 @@ class CaseInsensitiveFieldAccessor
 
         // Correct case (and getters)
         if ($object->hasField($objectFieldName)) {
-            return $object->{$objectFieldName};
+            return $asObject ? $object->obj($objectFieldName) : $object->{$objectFieldName};
         }
 
         return null;

--- a/src/Util/CaseInsensitiveFieldAccessor.php
+++ b/src/Util/CaseInsensitiveFieldAccessor.php
@@ -60,7 +60,7 @@ class CaseInsensitiveFieldAccessor implements FieldAccessorInterface
 
         // Correct case for methods (e.g. canView)
         if ($object->hasMethod($objectFieldName)) {
-            return $object->{$objectFieldName}();
+            return $asObject ? $object->obj($objectFieldName) : $object->{$objectFieldName}();
         }
 
         // Correct case (and getters)

--- a/src/Util/NaiveFieldAccessor.php
+++ b/src/Util/NaiveFieldAccessor.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Util;
+
+use SilverStripe\GraphQL\FieldAccessorInterface;
+use SilverStripe\View\ViewableData;
+
+class NaiveFieldAccessor implements FieldAccessorInterface
+{
+    public function getValue(ViewableData $object, $fieldName, $opts = [], $asObject = false)
+    {
+        return $object->obj($fieldName);
+    }
+
+    public function setValue(ViewableData $object, $fieldName, $value, $opts = [])
+    {
+        $object->$fieldName = $alue;
+    }
+
+    public function getObjectFieldName(ViewableData $object, $fieldName, $opts = [])
+    {
+        return $fieldName;
+    }
+}


### PR DESCRIPTION
We need backward compat for all the core modules, so they can run on either v3 or v4. It's very difficult to do this at run time because the graphql queries are bound to components at build time, so having two separate queries is both a technical challenge and also hard to maintain.

The easier solution is to allow the graphql 3 queries to look like graphql 4 queries, and the main issue there is case sensitivity.

This pull request allows the optional provision of a field formatter function and field accessor service to abstract this away. By default, you still get the naive implementation of DBField == GraphQL Field, but in admin, we'll want to take advantage of a lowerCamelCase transform.

Todo:
* Unit testing
* Documentation (v3 only)