### PR TITLE
Schema warning when model can't be found

### DIFF
--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -230,6 +230,11 @@ class Schema implements ConfigurationApplier, SchemaValidator, SignatureProvider
         static::assertValidConfig($models);
         foreach ($models as $modelName => $modelConfig) {
              $model = $this->createModel($modelName, $modelConfig);
+             Schema::invariant(
+                 $model,
+                 'No model found for "%s". Maybe the class does not exist?',
+                 $modelName
+             );
              $this->addModel($model);
         }
 


### PR DESCRIPTION
It's unclear whether `SchemaModelCreatorInterface`
should support model identifiers which aren't classes,
so I've refrained from using `class_exists()` directly here.