### PR TITLE
NEW Validate schema keys

### DIFF
--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -184,6 +184,23 @@ class Schema implements ConfigurationApplier, SchemaValidator, SignatureProvider
         $scalars = $schemaConfig[self::SCALARS] ?? [];
         $modelConfig = $schemaConfig[self::MODEL_CONFIG] ?? [];
 
+
+        $validConfigKeys = [
+            self::DEFAULTS,
+            self::TYPES,
+            self::QUERIES,
+            self::MUTATIONS,
+            self::INTERFACES,
+            self::UNIONS,
+            self::MODELS,
+            self::ENUMS,
+            self::SCALARS,
+            self::MODEL_CONFIG,
+            'builders',
+            'src',
+        ];
+        static::assertValidConfig($schemaConfig, $validConfigKeys);
+
         $this->defaults = $defaults;
 
         // Configure the models


### PR DESCRIPTION
Prevents "forgetting" a level. In this example, I've forgotten the "models" key, which means the schema build will just finish without any output or error.

SilverStripe\GraphQL\Schema\Schema:
  schemas:
    default:
      SilverStripe\CMS\Model\SiteTree:
        fields:
          '*': true

The downside of this approach is that we can't easily extend the schema with new keys
through modules building on silverstripe/graphql, but I'd say we cross that bridge when the need arises.