### PR TITLE
NEW: Stateless plugins, plugin registry as simple list

### DIFF
--- a/_config/plugins.yml
+++ b/_config/plugins.yml
@@ -4,12 +4,12 @@ Name: graphql-plugins
 SilverStripe\Core\Injector\Injector:
   SilverStripe\GraphQL\Schema\Registry\PluginRegistry:
     constructor:
-      paginator: '%$SilverStripe\GraphQL\Schema\Plugin\PaginationPlugin'
-      dataobjectPaginator: '%$SilverStripe\GraphQL\Schema\DataObject\Plugin\Paginator'
-      dataobjectQueryFilter: '%$SilverStripe\GraphQL\Schema\DataObject\Plugin\QueryFilter\QueryFilter'
-      dataobjectQuerySort: '%$SilverStripe\GraphQL\Schema\DataObject\Plugin\QuerySort'
-      dataobjectInheritance: '%$SilverStripe\GraphQL\Schema\DataObject\Plugin\Inheritance'
-      canViewPermission: '%$SilverStripe\GraphQL\Schema\DataObject\Plugin\CanViewPermission'
-      firstResult: '%$SilverStripe\GraphQL\Schema\DataObject\Plugin\FirstResult'
-      inheritedPlugins: '%$SilverStripe\GraphQL\Schema\DataObject\Plugin\InheritedPlugins'
-      sorter: '%$SilverStripe\GraphQL\Schema\Plugin\SortPlugin'
+      - 'SilverStripe\GraphQL\Schema\Plugin\PaginationPlugin'
+      - 'SilverStripe\GraphQL\Schema\DataObject\Plugin\Paginator'
+      - 'SilverStripe\GraphQL\Schema\DataObject\Plugin\QueryFilter\QueryFilter'
+      - 'SilverStripe\GraphQL\Schema\DataObject\Plugin\QuerySort'
+      - 'SilverStripe\GraphQL\Schema\DataObject\Plugin\Inheritance'
+      - 'SilverStripe\GraphQL\Schema\DataObject\Plugin\CanViewPermission'
+      - 'SilverStripe\GraphQL\Schema\DataObject\Plugin\FirstResult'
+      - 'SilverStripe\GraphQL\Schema\DataObject\Plugin\InheritedPlugins'
+      - 'SilverStripe\GraphQL\Schema\Plugin\SortPlugin'

--- a/src/Schema/Plugin/AbstractNestedInputPlugin.php
+++ b/src/Schema/Plugin/AbstractNestedInputPlugin.php
@@ -162,7 +162,7 @@ abstract class AbstractNestedInputPlugin implements ModelFieldPlugin
                 $filters[$fieldObj->getName()] = true;
             }
         }
-        $this->_allConfigCache[$modelType->getName()] = $filters;
+        $this->_allConfigCache[$key] = $filters;
 
         return $filters;
     }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -406,6 +406,8 @@ class Schema implements ConfigurationApplier, SchemaValidator, SignatureProvider
             // Duck programming here just because there is such an exhaustive list of possible
             // interfaces, and they can't have a common ancestor until PHP 7.4 allows it.
             // https://wiki.php.net/rfc/covariant-returns-and-contravariant-parameters
+            // ideally, this should be `instanceof PluginInterface` and PluginInterface should have
+            // apply(SchemaComponent)
             if (!method_exists($plugin, 'apply')) {
                 continue;
             }


### PR DESCRIPTION
This fixes a number of errors that could come up when doing multiple schema builds where plugin state was polluted by preceding schemas. Plugins are no longer singletons, and are instead instantiated each time they are used. State that should be persisted for the duration of the build should be in static members, namespaced by the current schema.

## Interdependent PRs

- [ ] https://github.com/silverstripe/silverstripe-framework/pull/9777
- [ ] https://github.com/silverstripe/silverstripe-cms/pull/2615
- [ ] https://github.com/silverstripe/silverstripe-versioned/pull/314