### PR TITLE
ENHANCEMENT: Resolver strategy isn't logical

### DIFF
--- a/src/Config/SchemaContext.php
+++ b/src/Config/SchemaContext.php
@@ -93,11 +93,10 @@ class SchemaContext extends AbstractConfiguration
             is_callable($strategy),
             'SchemaContext resolverStrategy must be callable'
         );
-        foreach ($this->getResolvers() as $className) {
-            $resolver = call_user_func_array($strategy, [$className, $typeName, $field]);
-            if ($resolver) {
-                return ResolverReference::create([$className, $resolver]);
-            }
+
+        $callable = call_user_func_array($strategy, [$this->getResolvers(), $typeName, $field]);
+        if ($callable) {
+            return ResolverReference::create($callable);
         }
 
         $default = $field->getDefaultResolver();

--- a/src/Schema/Resolver/DefaultResolverStrategy.php
+++ b/src/Schema/Resolver/DefaultResolverStrategy.php
@@ -15,12 +15,12 @@ use SilverStripe\GraphQL\Schema\Interfaces\ResolverProvider;
 class DefaultResolverStrategy
 {
     /**
-     * @param string $className
+     * @param array $resolverClasses
      * @param string|null $typeName
      * @param Field|null $field
-     * @return string|null
+     * @return callable|null
      */
-    public static function getResolverMethod(string $className, ?string $typeName = null, ?Field $field = null): ?string
+    public static function getResolverMethod(array $resolverClasses, ?string $typeName = null, ?Field $field = null): ?callable
     {
         $fieldName = $field->getName();
         $candidates = array_filter([
@@ -49,10 +49,12 @@ class DefaultResolverStrategy
         ]);
 
         foreach ($candidates as $method) {
-            $callable = [$className, $method];
-            $isCallable = is_callable($callable, false);
-            if ($isCallable) {
-                return $method;
+            foreach ($resolverClasses as $className) {
+                $callable = [$className, $method];
+                $isCallable = is_callable($callable, false);
+                if ($isCallable) {
+                    return $callable;
+                }
             }
         }
 


### PR DESCRIPTION
The current logic is:

"For each resolver class, try very specific methods, down to really generic methods. "

This means a class with a generic method defined that is first in the resolver list will beat out a class with a more specific method that happens to be lower in the list. The outer loop should be the decreasing specificity of methods, and the inner loop should be the classes.