### PR TITLE
ENHANCEMENT: Code gen stores entire config array

### DIFF
--- a/src/Config/AbstractConfiguration.php
+++ b/src/Config/AbstractConfiguration.php
@@ -92,4 +92,12 @@ abstract class AbstractConfiguration
 
         return $this;
     }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return $this->settings;
+    }
 }

--- a/src/Schema/Interfaces/SchemaStorageInterface.php
+++ b/src/Schema/Interfaces/SchemaStorageInterface.php
@@ -4,8 +4,10 @@
 namespace SilverStripe\GraphQL\Schema\Interfaces;
 
 use GraphQL\Type\Schema as GraphQLSchema;
+use GraphQL\Type\SchemaConfig;
 use SilverStripe\GraphQL\Schema\Exception\SchemaNotFoundException;
 use SilverStripe\GraphQL\Schema\Schema;
+use SilverStripe\GraphQL\Schema\SchemaContext;
 
 /**
  * Persists a graphql-php Schema object, and retrieves it
@@ -26,9 +28,9 @@ interface SchemaStorageInterface
     public function getSchema(): GraphQLSchema;
 
     /**
-     * @return array
+     * @return SchemaContext
      */
-    public function getTypeMapping(): array;
+    public function getContext(): SchemaContext;
 
     /**
      * @return void

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -627,7 +627,7 @@ class Schema implements ConfigurationApplier, SchemaValidator, SignatureProvider
      */
     public function getTypeNameForClass(string $class): ?string
     {
-        $mapping = $this->getStore()->getTypeMapping();
+        $mapping = $this->getStore()->getContext()->get('typeMapping', []);
         $typeName = $mapping[$class] ?? null;
         if ($typeName) {
             return $typeName;

--- a/src/Schema/Type/Enum.php
+++ b/src/Schema/Type/Enum.php
@@ -6,6 +6,7 @@ namespace SilverStripe\GraphQL\Schema\Type;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Interfaces\SchemaValidator;
 use SilverStripe\GraphQL\Schema\Schema;
+use SilverStripe\ORM\ArrayLib;
 
 /**
  * Abstraction for enum types
@@ -48,7 +49,12 @@ class Enum extends Type implements SchemaValidator
     public function getValueList(): array
     {
         $list = [];
-        foreach ($this->getValues() as $key => $val) {
+        $values = $this->getValues();
+        if (!ArrayLib::is_associative($values)) {
+            $list = array_values($values);
+            $values = array_combine($list, $list);
+        }
+        foreach ($values as $key => $val) {
             $value = null;
             $description = null;
             if (is_array($val)) {


### PR DESCRIPTION
This came up as part of an upgrade to silverstripe-gatsby. Only storing type-mapping in the code gen store seems a bit limited and arbitrary.