### PR TITLE
FIX Use require instead of require_once for type mapping function

### DIFF
--- a/src/Schema/Storage/CodeGenerationStore.php
+++ b/src/Schema/Storage/CodeGenerationStore.php
@@ -283,7 +283,7 @@ class CodeGenerationStore implements SchemaStorageInterface
     public function getTypeMapping(): array
     {
         if (file_exists($this->getTypeMappingFilename())) {
-            $mapping = require_once($this->getTypeMappingFilename());
+            $mapping = require($this->getTypeMappingFilename());
 
             return $mapping;
         }


### PR DESCRIPTION
I get this when I go to /admin/pages on a site with elemental installed

[Emergency] Uncaught TypeError: Return value of SilverStripe\GraphQL\Schema\Storage\CodeGenerationStore::getTypeMapping() must be of the type array, boolean returned

The file it's trying to retrieve is /.graphql/admin/__type-mapping.php

The contents of the file is 
```
<?php 
return array (
  'DNADesign\\Elemental\\Models\\BaseElement' => 'Block',
...
  'SilverStripe\\CMS\\Model\\VirtualPage' => 'VirtualPage',
);
```

What's happening is that this line is being called more than once, and `require_once` will return a bool(true) for each subsequent call.

Instead we should just use `require` so that it always reads the file and assigns the read value to `$mapping`
