### PR TITLE
FIX Handle case where params is empty

### DIFF
--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -996,11 +996,10 @@ class Schema implements ConfigurationApplier, SchemaValidator
     public static function invariant($test, $message = '', ...$params): void
     {
         if (!$test) {
-            $message = sprintf($message, ...$params);
+            $message = count($params) > 0 ? sprintf($message, ...$params) : $message;
             throw new SchemaBuilderException($message);
         }
     }
-
 
     /**
      * @return SchemaStorageInterface


### PR DESCRIPTION
sprintf() will fail if passed an empty array i.e. `...[]`

This fix ensure we don't attempt to use sprintf() when this happens