### PR TITLE
FIX: input building in cyclic graphs

### DIFF
--- a/src/Schema/Services/NestedInputBuilder.php
+++ b/src/Schema/Services/NestedInputBuilder.php
@@ -123,8 +123,8 @@ class NestedInputBuilder
      * @return array
      * @throws SchemaBuilderException
      */
-     protected function buildAllFieldsConfig(Type $type, int $level = 0, array &$seenConnections = []): array
-     {
+    protected function buildAllFieldsConfig(Type $type, int $level = 0, array &$seenConnections = []): array
+    {
         $existing = $this->fetch($type->getName());
         if ($existing) {
             return $existing;
@@ -159,7 +159,7 @@ class NestedInputBuilder
         }
         $this->persist($type->getName(), $map);
         return $map;
-     }
+    }
 
     /**
      * @param Type $type

--- a/src/Schema/Services/NestedInputBuilder.php
+++ b/src/Schema/Services/NestedInputBuilder.php
@@ -27,12 +27,6 @@ class NestedInputBuilder
     const SELF_REFERENTIAL = '--self--';
 
     /**
-     * @var int
-     * @config
-     */
-    private static $max_nesting = 3;
-
-    /**
      * @var string
      * @config
      */

--- a/src/Schema/Services/NestedInputBuilder.php
+++ b/src/Schema/Services/NestedInputBuilder.php
@@ -156,7 +156,7 @@ class NestedInputBuilder
         }
         $this->persist($type->getName(), $map);
         return $map;
-     }
+    }
 
     /**
      * @param Type $type

--- a/tests/Schema/Services/NestedInputBuilderTest.php
+++ b/tests/Schema/Services/NestedInputBuilderTest.php
@@ -105,7 +105,7 @@ class NestedInputBuilderTest extends SapphireTest
         $this->assertNotNull($filterType, "Type FakeReviewFilterFields not found in schema");
         $filterFieldObj = $filterType->getFieldByName('author');
         $this->assertNotNull($filterFieldObj, "Field author not found on {$filterType->getName()}");
-        $this->assertEquals('MemberFilterFields', $fieldObj->filterFieldObj());
+        $this->assertEquals('MemberFilterFields', $filterFieldObj->filterFieldObj());
     }
 
     private function assertSchema(array $graph, Schema $schema)

--- a/tests/Schema/Services/NestedInputBuilderTest.php
+++ b/tests/Schema/Services/NestedInputBuilderTest.php
@@ -105,7 +105,7 @@ class NestedInputBuilderTest extends SapphireTest
         $this->assertNotNull($filterType, "Type FakeReviewFilterFields not found in schema");
         $filterFieldObj = $filterType->getFieldByName('author');
         $this->assertNotNull($filterFieldObj, "Field author not found on {$filterType->getName()}");
-        $this->assertEquals('MemberFilterFields', $filterFieldObj->filterFieldObj());
+        $this->assertEquals('MemberFilterFields', $filterFieldObj->getType());
     }
 
     private function assertSchema(array $graph, Schema $schema)

--- a/tests/Schema/Services/NestedInputBuilderTest.php
+++ b/tests/Schema/Services/NestedInputBuilderTest.php
@@ -101,13 +101,11 @@ class NestedInputBuilderTest extends SapphireTest
                 $model->addField('firstName');
             });
         $schema->createStoreableSchema();
-        $this->assertSchema([
-            'FakeReviewFilterFields' => [
-                'id' => 'QueryFilterIDComparator',
-                'content' => 'QueryFilterStringComparator',
-                'author' => 'MemberFilterFields'
-            ]
-        ], $schema);
+        $filterType = $schema->getType('FakeReviewFilterFields');
+        $this->assertNotNull($filterType, "Type FakeReviewFilterFields not found in schema");
+        $filterFieldObj = $filterType->getFieldByName('author');
+        $this->assertNotNull($filterFieldObj, "Field author not found on {$filterType->getName()}");
+        $this->assertEquals('MemberFilterFields', $fieldObj->filterFieldObj());
     }
 
     private function assertSchema(array $graph, Schema $schema)

--- a/tests/Schema/Services/NestedInputBuilderTest.php
+++ b/tests/Schema/Services/NestedInputBuilderTest.php
@@ -75,18 +75,17 @@ class NestedInputBuilderTest extends SapphireTest
             ],
         ], $schema);
     }
-    
+
     /**
      * @throws SchemaBuilderException
      */
-    public function testNestedInputBuilderBuildsCyclic()
+    public function testNestedInputBuilderBuildsCyclicFilterFields()
     {
-        $schema = (new TestSchemaBuilder())->boot('inputBuilderTest');
+        $schema = (new TestSchemaBuilder())->boot('filterfieldbuilder');
         $schema
             ->addModelbyClassName(FakeProductPage::class, function (ModelType $model) {
                 $model->addField('title');
-                $model->addField('products');
-                $model->addAllOperations();
+                $model->addField('products', ['plugins' => ['filter' => true]]);
             })
             ->addModelbyClassName(FakeProduct::class, function (ModelType $model) {
                 $model->addField('title');
@@ -97,21 +96,16 @@ class NestedInputBuilderTest extends SapphireTest
             ->addModelbyClassName(FakeReview::class, function (ModelType $model) {
                 $model->addField('content');
                 $model->addField('author');
-                $model->addAllOperations();
             })
             ->addModelbyClassName(Member::class, function (ModelType $model) {
                 $model->addField('firstName');
             });
-        $root = $schema->getModelByClassName(FakeProductPage::class);
-        $query = Query::create('myQuery', '[' . $root->getName() . ']');
-
-        $builder = NestedInputBuilder::create($query, $schema);
-        $builder->populateSchema();
+        $schema->createStoreableSchema();
         $this->assertSchema([
-            'FakeReviewFilterFieldsType' => [
+            'FakeReviewFilterFields' => [
                 'id' => 'QueryFilterIDComparator',
                 'content' => 'QueryFilterStringComparator',
-                'author' => 'MemberFilterFieldsType'
+                'author' => 'MemberFilterFields'
             ]
         ], $schema);
     }


### PR DESCRIPTION
This PR aims to fix a bug in the `NestedInputBuilder` where a cyclic graph prohibits the building of all necessary nested types on filter and sort input-types.