### PR TITLE
NEW: Replace _extends in favour of Unions/Interfaces

### DIFF
--- a/_config/dataobject.yml
+++ b/_config/dataobject.yml
@@ -3,7 +3,6 @@ Name: silverstripe-graphql-dataobject
 ---
 SilverStripe\ORM\DataObject:
   graphql_blacklisted_fields:
-    ClassName: true
     LinkTracking: true
     FileTracking: true
   extensions:

--- a/_config/dbtypes.yml
+++ b/_config/dbtypes.yml
@@ -13,6 +13,6 @@ SilverStripe\ORM\FieldType\DBFloat:
 SilverStripe\ORM\FieldType\DBDecimal:
   graphql_type: Float
 SilverStripe\ORM\FieldType\DBPrimaryKey:
-  graphql_type: ID
+  graphql_type: ID!
 SilverStripe\ORM\FieldType\DBForeignKey:
-  graphql_type: ID
+  graphql_type: ID!

--- a/_config/schema-global.yml
+++ b/_config/schema-global.yml
@@ -14,8 +14,6 @@ SilverStripe\GraphQL\Schema\Schema:
         defaultResolver: 'SilverStripe\GraphQL\Schema\Resolver\DefaultResolver::defaultFieldResolver'
         modelCreators:
           - 'SilverStripe\GraphQL\Schema\DataObject\ModelCreator'
-        inheritance:
-          useUnionQueries: true
         modelConfig:
           DataObject:
             type_formatter: 'SilverStripe\Core\ClassInfo::shortName'
@@ -24,7 +22,8 @@ SilverStripe\GraphQL\Schema\Schema:
             base_fields:
               ID: ID
             plugins:
-              inheritance: true
+              inheritance:
+                useUnionQueries: false
               inheritedPlugins:
                 after: '*'
             operations:

--- a/_config/schema-global.yml
+++ b/_config/schema-global.yml
@@ -5,7 +5,7 @@ SilverStripe\GraphQL\Schema\Schema:
   schemas:
     '*':
       scalars:
-        JSON:
+        JSONBlob:
           serialiser: 'SilverStripe\GraphQL\Schema\Resolver\JSONResolver::serialise'
           valueParser: 'SilverStripe\GraphQL\Schema\Resolver\JSONResolver::parseValue'
           literalParser: 'SilverStripe\GraphQL\Schema\Resolver\JSONResolver::parseLiteral'
@@ -21,7 +21,7 @@ SilverStripe\GraphQL\Schema\Schema:
             type_formatter: 'SilverStripe\Core\ClassInfo::shortName'
             type_prefix: ''
             type_mapping: []
-            default_fields:
+            base_fields:
               ID: ID
             plugins:
               inheritance: true

--- a/_config/schema-global.yml
+++ b/_config/schema-global.yml
@@ -4,16 +4,25 @@ Name: 'graphql-schema-global'
 SilverStripe\GraphQL\Schema\Schema:
   schemas:
     '*':
+      scalars:
+        JSON:
+          serialiser: 'SilverStripe\GraphQL\Schema\Resolver\JSONResolver::serialise'
+          valueParser: 'SilverStripe\GraphQL\Schema\Resolver\JSONResolver::parseValue'
+          literalParser: 'SilverStripe\GraphQL\Schema\Resolver\JSONResolver::parseLiteral'
       config:
         resolverStrategy: 'SilverStripe\GraphQL\Schema\Resolver\DefaultResolverStrategy::getResolverMethod'
         defaultResolver: 'SilverStripe\GraphQL\Schema\Resolver\DefaultResolver::defaultFieldResolver'
         modelCreators:
           - 'SilverStripe\GraphQL\Schema\DataObject\ModelCreator'
+        inheritance:
+          useUnionQueries: true
         modelConfig:
           DataObject:
             type_formatter: 'SilverStripe\Core\ClassInfo::shortName'
             type_prefix: ''
             type_mapping: []
+            default_fields:
+              ID: ID
             plugins:
               inheritance: true
               inheritedPlugins:

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -53,11 +53,11 @@ class Configuration
 
     /**
      * @param $path
-     * @param $value
+     * @param callable $callback
      * @return $this
      * @throws SchemaBuilderException
      */
-    public function set($path, $value): self
+    private function path($path, $callback): void
     {
         if (is_string($path)) {
             $path = explode('.', $path);
@@ -72,14 +72,44 @@ class Configuration
         foreach ($path as $i => $part) {
             $last = ($i + 1) === sizeof($path);
             if ($last) {
-                $scope[$part] = $value;
-                return $this;
+                $callback($scope, $part);
+                return;
             }
             if (!isset($scope[$part])) {
                 $scope[$part] = [];
             }
             $scope = &$scope[$part];
         }
+    }
+
+    /**
+     * @param $path
+     * @param $value
+     * @return $this
+     * @throws SchemaBuilderException
+     */
+    public function set($path, $value): self
+    {
+        $this->path($path, function (&$scope, $part) use ($value) {
+           $scope[$part] = $value;
+        });
+
+        return $this;
+    }
+
+    /**
+     * @param $path
+     * @param $value
+     * @return $this
+     * @throws SchemaBuilderException
+     */
+    public function unset($path): self
+    {
+        $this->path($path, function (&$scope, $part) {
+            unset($scope[$part]);
+        });
+
+        return $this;
     }
 
     /**

--- a/src/Config/ModelConfiguration.php
+++ b/src/Config/ModelConfiguration.php
@@ -65,12 +65,23 @@ class ModelConfiguration extends Configuration
     }
 
     /**
+     * Fields that are added to the model by default. Can be opted out per type
      * @return array
      * @throws SchemaBuilderException
      */
     public function getDefaultFields(): array
     {
         return $this->get('default_fields', []);
+    }
+
+    /**
+     * Fields that will appear on all models. Cannot be opted out on any type.
+     * @return array
+     * @throws SchemaBuilderException
+     */
+    public function getBaseFields(): array
+    {
+        return $this->get('base_fields', []);
     }
 
     /**

--- a/src/Config/ModelConfiguration.php
+++ b/src/Config/ModelConfiguration.php
@@ -65,6 +65,15 @@ class ModelConfiguration extends Configuration
     }
 
     /**
+     * @return array
+     * @throws SchemaBuilderException
+     */
+    public function getDefaultFields(): array
+    {
+        return $this->get('default_fields', []);
+    }
+
+    /**
      * @param string $class
      * @return string
      * @throws SchemaBuilderException

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -147,7 +147,6 @@ class Controller extends BaseController
             $event = QueryHandler::isMutation($query) ? 'onGraphQLMutation' : 'onGraphQLQuery';
             $operationName = QueryHandler::getOperationName($queryDocument);
             Dispatcher::singleton()->trigger($event, Event::create($operationName, $eventContext));
-
         } catch (Exception $exception) {
             $error = ['message' => $exception->getMessage()];
 

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -16,12 +16,12 @@ use SilverStripe\EventDispatcher\Symfony\Event;
 use SilverStripe\GraphQL\Auth\Handler;
 use SilverStripe\GraphQL\PersistedQuery\RequestProcessor;
 use SilverStripe\GraphQL\QueryHandler\QueryHandlerInterface;
+use SilverStripe\GraphQL\QueryHandler\QueryStateProvider;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\QueryHandler\RequestContextProvider;
-use SilverStripe\GraphQL\QueryHandler\SchemaContextProvider;
+use SilverStripe\GraphQL\QueryHandler\SchemaConfigProvider;
 use SilverStripe\GraphQL\QueryHandler\TokenContextProvider;
 use SilverStripe\GraphQL\QueryHandler\UserContextProvider;
-use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\GraphQL\Schema\SchemaBuilder;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
@@ -305,8 +305,9 @@ class Controller extends BaseController
                 ->addContextProvider(RequestContextProvider::create($request));
         $schemaContext = SchemaBuilder::singleton()->getConfig($this->getSchemaKey());
         if ($schemaContext) {
-            $handler->addContextProvider(SchemaContextProvider::create($schemaContext));
+            $handler->addContextProvider(SchemaConfigProvider::create($schemaContext));
         }
+        $handler->addContextProvider(QueryStateProvider::create());
     }
 
     /**

--- a/src/Dev/Build.php
+++ b/src/Dev/Build.php
@@ -3,6 +3,7 @@
 
 namespace SilverStripe\GraphQL\Dev;
 
+use GraphQL\Utils\SchemaPrinter;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;

--- a/src/Dev/Build.php
+++ b/src/Dev/Build.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Dev;
 
-use GraphQL\Utils\SchemaPrinter;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
@@ -13,7 +12,6 @@ use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Exception\SchemaNotFoundException;
 use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\GraphQL\Schema\SchemaBuilder;
-use SilverStripe\ORM\DatabaseAdmin;
 
 class Build extends Controller
 {

--- a/src/QueryHandler/QueryHandler.php
+++ b/src/QueryHandler/QueryHandler.php
@@ -205,16 +205,6 @@ class QueryHandler implements
     }
 
     /**
-     * @return array
-     */
-    protected function getContextDefaults(): array
-    {
-        return [
-            self::CURRENT_USER => $this->getMemberContext(),
-        ];
-    }
-
-    /**
      * Call middleware to evaluate a graphql query
      *
      * @param GraphQLSchema $schema

--- a/src/QueryHandler/QueryHandler.php
+++ b/src/QueryHandler/QueryHandler.php
@@ -342,5 +342,4 @@ class QueryHandler implements
         }
         return 'graphql';
     }
-
 }

--- a/src/QueryHandler/QueryHandlerInterface.php
+++ b/src/QueryHandler/QueryHandlerInterface.php
@@ -4,6 +4,7 @@
 namespace SilverStripe\GraphQL\QueryHandler;
 
 use GraphQL\Executor\ExecutionResult;
+use GraphQL\Language\AST\DocumentNode;
 use GraphQL\Type\Schema;
 use SilverStripe\GraphQL\Schema\Interfaces\ContextProvider;
 
@@ -13,7 +14,13 @@ use SilverStripe\GraphQL\Schema\Interfaces\ContextProvider;
  */
 interface QueryHandlerInterface
 {
-    public function query(Schema $schema, string $query, array $params = []): array;
+    /**
+     * @param Schema $schema
+     * @param string|DocumentNode $query
+     * @param array $params
+     * @return array
+     */
+    public function query(Schema $schema, $query, array $params = []): array;
 
     /**
      * Serialise a Graphql result object for output

--- a/src/QueryHandler/QueryStateProvider.php
+++ b/src/QueryHandler/QueryStateProvider.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\QueryHandler;
 
-
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\GraphQL\Config\Configuration;
 use SilverStripe\GraphQL\Schema\Interfaces\ContextProvider;
@@ -50,5 +49,4 @@ class QueryStateProvider implements ContextProvider
             self::KEY => $this->queryState,
         ];
     }
-
 }

--- a/src/QueryHandler/QueryStateProvider.php
+++ b/src/QueryHandler/QueryStateProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\QueryHandler;
+
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\GraphQL\Config\Configuration;
+use SilverStripe\GraphQL\Schema\Interfaces\ContextProvider;
+
+/**
+ * Provides an arbitrary state container that can be passed through
+ * the resolver chain. It is empty by default and derives
+ * no state from the actual schema
+ */
+class QueryStateProvider implements ContextProvider
+{
+    use Injectable;
+
+    const KEY = 'queryState';
+
+    /**
+     * @var Configuration
+     */
+    private $queryState;
+
+    /**
+     * QueryStateProvider constructor.
+     */
+    public function __construct()
+    {
+        $this->queryState = new Configuration();
+    }
+
+    /**
+     * @param array $context
+     * @return mixed|null
+     */
+    public static function get(array $context): Configuration
+    {
+        return $context[self::KEY] ?? new Configuration();
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideContext(): array
+    {
+        return [
+            self::KEY => $this->queryState,
+        ];
+    }
+
+}

--- a/src/QueryHandler/SchemaConfigProvider.php
+++ b/src/QueryHandler/SchemaConfigProvider.php
@@ -7,7 +7,7 @@ use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\GraphQL\Schema\Interfaces\ContextProvider;
 use SilverStripe\GraphQL\Schema\SchemaConfig;
 
-class SchemaContextProvider implements ContextProvider
+class SchemaConfigProvider implements ContextProvider
 {
     use Injectable;
 
@@ -19,7 +19,7 @@ class SchemaContextProvider implements ContextProvider
     private $schemaConfig;
 
     /**
-     * SchemaContextProvider constructor.
+     * SchemaConfigProvider constructor.
      * @param SchemaConfig $schemaConfig
      */
     public function __construct(SchemaConfig $schemaConfig)

--- a/src/Schema/DataObject/AbstractTypeResolver.php
+++ b/src/Schema/DataObject/AbstractTypeResolver.php
@@ -1,0 +1,44 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Schema\DataObject;
+
+
+use SilverStripe\GraphQL\QueryHandler\SchemaConfigProvider;
+use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
+use SilverStripe\GraphQL\Schema\Schema;
+use SilverStripe\ORM\DataObject;
+use Exception;
+
+class AbstractTypeResolver
+{
+    /**
+     * @param $obj
+     * @param $context
+     * @return string
+     * @throws SchemaBuilderException
+     * @throws Exception
+     */
+    public static function resolveType($obj, $context): string
+    {
+        $class = get_class($obj);
+        $schemaContext = SchemaConfigProvider::get($context);
+
+        while ($class && !$schemaContext->hasModel($class)) {
+            if ($class === DataObject::class) {
+                throw new Exception(sprintf(
+                    'No models were registered in the ancestry of %s',
+                    get_class($obj)
+                ));
+            }
+            $class = get_parent_class($class);
+            Schema::invariant(
+                $class,
+                'Could not resolve type for %s.',
+                get_class($obj)
+            );
+        }
+        return $schemaContext->getTypeNameForClass($class);
+    }
+
+}

--- a/src/Schema/DataObject/AbstractTypeResolver.php
+++ b/src/Schema/DataObject/AbstractTypeResolver.php
@@ -9,6 +9,9 @@ use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\ORM\DataObject;
 use Exception;
 
+/**
+ * Used for unions and interfaces to map a class instance to a type
+ */
 class AbstractTypeResolver
 {
     /**

--- a/src/Schema/DataObject/AbstractTypeResolver.php
+++ b/src/Schema/DataObject/AbstractTypeResolver.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Schema\DataObject;
 
-
 use SilverStripe\GraphQL\QueryHandler\SchemaConfigProvider;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Schema;
@@ -40,5 +39,4 @@ class AbstractTypeResolver
         }
         return $schemaContext->getTypeNameForClass($class);
     }
-
 }

--- a/src/Schema/DataObject/CreateCreator.php
+++ b/src/Schema/DataObject/CreateCreator.php
@@ -134,7 +134,7 @@ class CreateCreator implements OperationCreator, InputTypeProvider
             if (!$fieldObj) {
                 continue;
             }
-            $type = $fieldObj->getType();
+            $type = $fieldObj->getNamedType();
             if ($type && Schema::isInternalType($type)) {
                 $fieldMap[$fieldName] = $type;
             }

--- a/src/Schema/DataObject/CreateCreator.php
+++ b/src/Schema/DataObject/CreateCreator.php
@@ -8,7 +8,7 @@ use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\GraphQL\QueryHandler\QueryHandler;
-use SilverStripe\GraphQL\QueryHandler\SchemaContextProvider;
+use SilverStripe\GraphQL\QueryHandler\SchemaConfigProvider;
 use SilverStripe\GraphQL\QueryHandler\UserContextProvider;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Field\ModelMutation;
@@ -81,12 +81,12 @@ class CreateCreator implements OperationCreator, InputTypeProvider
             if (!$dataClass) {
                 return null;
             }
-            $schema = SchemaContextProvider::get($context);
+            $schema = SchemaConfigProvider::get($context);
             Schema::invariant(
                 $schema,
                 'Could not access schema in resolver for %s. Did you not add the %s context provider?',
                 __CLASS__,
-                SchemaContextProvider::class
+                SchemaConfigProvider::class
             );
             $singleton = Injector::inst()->get($dataClass);
             $member = UserContextProvider::get($context);

--- a/src/Schema/DataObject/DataObjectModel.php
+++ b/src/Schema/DataObject/DataObjectModel.php
@@ -9,6 +9,7 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\GraphQL\Config\ModelConfiguration;
 use SilverStripe\GraphQL\Schema\Field\ModelField;
 use SilverStripe\GraphQL\Schema\Field\ModelQuery;
+use SilverStripe\GraphQL\Schema\Interfaces\BaseFieldsProvider;
 use SilverStripe\GraphQL\Schema\Interfaces\DefaultFieldsProvider;
 use SilverStripe\GraphQL\Schema\Interfaces\ModelBlacklist;
 use SilverStripe\GraphQL\Schema\Resolver\ResolverReference;
@@ -31,6 +32,7 @@ class DataObjectModel implements
     SchemaModelInterface,
     OperationProvider,
     DefaultFieldsProvider,
+    BaseFieldsProvider,
     ModelBlacklist
 {
     use Injectable;
@@ -151,6 +153,28 @@ class DataObjectModel implements
             if ($type === false) {
                 continue;
             }
+            $formatted = $this->getFieldAccessor()->formatField($name);
+            $map[$formatted] = $type;
+        }
+
+        return $map;
+    }
+
+    /**
+     * @return array
+     * @throws SchemaBuilderException
+     */
+    public function getBaseFields(): array
+    {
+        $fields = $this->getModelConfiguration()->getBaseFields();
+        $map = [];
+        foreach ($fields as $name => $type) {
+            Schema::invariant(
+                $type,
+                'Default field %s cannot be falsy on %s',
+                $name,
+                $this->getSourceClass()
+            );
             $formatted = $this->getFieldAccessor()->formatField($name);
             $map[$formatted] = $type;
         }

--- a/src/Schema/DataObject/DataObjectModel.php
+++ b/src/Schema/DataObject/DataObjectModel.php
@@ -141,13 +141,21 @@ class DataObjectModel implements
 
     /**
      * @return array
+     * @throws SchemaBuilderException
      */
     public function getDefaultFields(): array
     {
-        $idField = $this->getFieldAccessor()->formatField('ID');
-        return [
-            $idField => 'ID',
-        ];
+        $fields = $this->getModelConfiguration()->getDefaultFields();
+        $map = [];
+        foreach ($fields as $name => $type) {
+            if ($type === false) {
+                continue;
+            }
+            $formatted = $this->getFieldAccessor()->formatField($name);
+            $map[$formatted] = $type;
+        }
+
+        return $map;
     }
 
     /**

--- a/src/Schema/DataObject/InheritanceBuilder.php
+++ b/src/Schema/DataObject/InheritanceBuilder.php
@@ -148,6 +148,4 @@ class InheritanceBuilder
         $this->schema = $schema;
         return $this;
     }
-
-
 }

--- a/src/Schema/DataObject/InheritanceBuilder.php
+++ b/src/Schema/DataObject/InheritanceBuilder.php
@@ -26,7 +26,7 @@ class InheritanceBuilder
 
     public function __construct(Schema $schema)
     {
-        $this->schema = $schema;
+        $this->setSchema($schema);
     }
 
     /**
@@ -94,6 +94,10 @@ class InheritanceBuilder
      */
     public function isBaseModel(string $class): bool
     {
+        if (!$this->getSchema()->getModelByClassName($class)) {
+            return false;
+        }
+
         $chain = InheritanceChain::create($class);
         if ($chain->getBaseClass() === $class) {
             return true;
@@ -114,6 +118,10 @@ class InheritanceBuilder
      */
     public function isLeafModel(string $class): bool
     {
+        if (!$this->getSchema()->getModelByClassName($class)) {
+            return false;
+        }
+
         $chain = InheritanceChain::create($class);
         foreach ($chain->getDescendantModels() as $class) {
             if ($this->getSchema()->getModelByClassName($class)) {

--- a/src/Schema/DataObject/InheritanceBuilder.php
+++ b/src/Schema/DataObject/InheritanceBuilder.php
@@ -1,0 +1,145 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Schema\DataObject;
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
+use SilverStripe\GraphQL\Schema\Field\ModelField;
+use SilverStripe\GraphQL\Schema\Schema;
+use SilverStripe\GraphQL\Schema\Type\ModelType;
+use ReflectionException;
+
+/**
+ * A schema-aware service for DataObject model types that builds out their
+ * inheritance chain in an ORM-like way, applying inherited fields and implicitly
+ * exposing ancestral types, etc.
+ */
+class InheritanceBuilder
+{
+    use Injectable;
+
+    /**
+     * @var Schema
+     */
+    private $schema;
+
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * @param ModelType $modelType
+     * @throws SchemaBuilderException
+     */
+    public function fillAncestry(ModelType $modelType): void
+    {
+        $chain = InheritanceChain::create($modelType->getModel()->getSourceClass());
+        $ancestors = $chain->getAncestralModels();
+        if (empty($ancestors)) {
+            return;
+        }
+        $parent = $ancestors[0];
+        $parentModel = $this->getSchema()->findOrMakeModel($parent);
+        // Merge descendant fields up into the ancestor
+        foreach ($modelType->getFields() as $fieldObj) {
+            // If the field already exists on the ancestor, skip it
+            if ($parentModel->getFieldByName($fieldObj->getName())) {
+                continue;
+            }
+            $fieldName = $fieldObj instanceof ModelField
+                ? $fieldObj->getPropertyName()
+                : $fieldObj->getName();
+            // If the field is unique to the descendant, skip it.
+            if ($parentModel->getModel()->hasField($fieldName)) {
+                $clone = clone $fieldObj;
+                $parentModel->addField($fieldObj->getName(), $clone);
+            }
+        }
+        $this->fillAncestry($parentModel);
+    }
+
+    /**
+     * @param ModelType $modelType
+     * @return void
+     * @throws ReflectionException
+     * @throws SchemaBuilderException
+     */
+    public function fillDescendants(ModelType $modelType): void
+    {
+        $chain = InheritanceChain::create($modelType->getModel()->getSourceClass());
+        $descendants = $chain->getDirectDescendants();
+        if (empty($descendants)) {
+            return;
+        }
+        foreach ($descendants as $descendant) {
+            $descendantModel = $this->getSchema()->getModelByClassName($descendant);
+            if ($descendantModel) {
+                foreach ($modelType->getFields() as $fieldObj) {
+                    if ($descendantModel->getFieldByName($fieldObj->getName())) {
+                        continue;
+                    }
+                    $clone = clone $fieldObj;
+                    $descendantModel->addField($fieldObj->getName(), $clone);
+                }
+                $this->fillDescendants($descendantModel);
+            }
+        }
+    }
+
+    /**
+     * @param string $class
+     * @return bool
+     */
+    public function isBaseModel(string $class): bool
+    {
+        $chain = InheritanceChain::create($class);
+        if ($chain->getBaseClass() === $class) {
+            return true;
+        }
+        foreach ($chain->getAncestralModels() as $class) {
+            if ($this->getSchema()->getModelByClassName($class)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $class
+     * @return bool
+     * @throws ReflectionException
+     */
+    public function isLeafModel(string $class): bool
+    {
+        $chain = InheritanceChain::create($class);
+        foreach ($chain->getDescendantModels() as $class) {
+            if ($this->getSchema()->getModelByClassName($class)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @return Schema
+     */
+    public function getSchema(): Schema
+    {
+        return $this->schema;
+    }
+
+    /**
+     * @param Schema $schema
+     * @return InheritanceBuilder
+     */
+    public function setSchema(Schema $schema): InheritanceBuilder
+    {
+        $this->schema = $schema;
+        return $this;
+    }
+
+
+}

--- a/src/Schema/DataObject/InheritanceChain.php
+++ b/src/Schema/DataObject/InheritanceChain.php
@@ -112,6 +112,24 @@ class InheritanceChain
     }
 
     /**
+     * @return bool
+     * @throws ReflectionException
+     */
+    public function hasInheritance(): bool
+    {
+        return $this->hasDescendants() || $this->hasAncestors();
+    }
+
+    /**
+     * @return array
+     * @throws ReflectionException
+     */
+    public function getInheritance(): array
+    {
+        return array_merge($this->getAncestralModels(), $this->getDescendantModels());
+    }
+
+    /**
      * @return string
      */
     public function getBaseClass(): string

--- a/src/Schema/DataObject/InheritanceUnionBuilder.php
+++ b/src/Schema/DataObject/InheritanceUnionBuilder.php
@@ -5,6 +5,7 @@ namespace SilverStripe\GraphQL\Schema\DataObject;
 
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
+use SilverStripe\GraphQL\Schema\Field\ModelField;
 use SilverStripe\GraphQL\Schema\Field\ModelQuery;
 use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\GraphQL\Schema\SchemaConfig;
@@ -89,7 +90,7 @@ class InheritanceUnionBuilder
         }
         foreach ($schema->getModels() as $model) {
             foreach ($model->getFields() as $field) {
-                if ($field instanceof ModelQuery) {
+                if ($field instanceof ModelField && $field->getModelType()) {
                     $queries[] = $field;
                 }
             }
@@ -99,7 +100,7 @@ class InheritanceUnionBuilder
                 continue;
             }
             foreach ($interface->getFields() as $field) {
-                if ($field instanceof ModelQuery) {
+                if ($field instanceof ModelField && $field->getModelType()) {
                     $queries[] = $field;
                 }
             }

--- a/src/Schema/DataObject/InheritanceUnionBuilder.php
+++ b/src/Schema/DataObject/InheritanceUnionBuilder.php
@@ -34,7 +34,7 @@ class InheritanceUnionBuilder
      */
     public function __construct(Schema $schema)
     {
-        $this->schema = $schema;
+        $this->setSchema($schema);
     }
 
     /**
@@ -53,9 +53,12 @@ class InheritanceUnionBuilder
             $name = static::unionName($modelType->getName(), $schema->getConfig());
             $union = ModelUnionType::create($modelType, $name);
 
-            $types = array_map(function ($class) use ($schema) {
+            $types = array_filter(array_map(function ($class) use ($schema) {
+                if (!$schema->getModelByClassName($class)) {
+                    return null;
+                }
                 return $schema->getConfig()->getTypeNameForClass($class);
-            }, $chain->getInheritance());
+            }, $chain->getInheritance()));
 
             $types[] = $modelType->getName();
 
@@ -123,7 +126,7 @@ class InheritanceUnionBuilder
     public static function unionName(string $modelName, SchemaConfig $schemaConfig): string
     {
         $callable = $schemaConfig->get(
-            'inheritance.union_formatter',
+            'inheritanceUnionBuilder.name_formatter',
             [static:: class, 'defaultUnionFormatter']
         );
         return $callable($modelName);

--- a/src/Schema/DataObject/InheritanceUnionBuilder.php
+++ b/src/Schema/DataObject/InheritanceUnionBuilder.php
@@ -1,0 +1,161 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Schema\DataObject;
+
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
+use SilverStripe\GraphQL\Schema\Field\ModelQuery;
+use SilverStripe\GraphQL\Schema\Schema;
+use SilverStripe\GraphQL\Schema\SchemaConfig;
+use SilverStripe\GraphQL\Schema\Type\ModelInterfaceType;
+use SilverStripe\GraphQL\Schema\Type\ModelUnionType;
+use SilverStripe\ORM\DataObject;
+use ReflectionException;
+
+/**
+ * A schema-aware services for DataObject model types that creates union types
+ * for all the members of an inheritance chain. Can also apply these unions
+ * to queries to enforce unions when return types have descendants.
+ */
+class InheritanceUnionBuilder
+{
+    use Injectable;
+
+    /**
+     * @var Schema
+     */
+    private $schema;
+
+    /**
+     * InheritanceUnionBuilder constructor.
+     * @param Schema $schema
+     */
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * @return void
+     * @throws ReflectionException
+     * @throws SchemaBuilderException
+     */
+    public function createUnions(): void
+    {
+        $dataObjects = $this->getSchema()->getModelTypesFromClass(DataObject::class);
+        $schema = $this->getSchema();
+
+        /* @var ModelInterfaceType $interface */
+        foreach ($dataObjects as $modelType) {
+            $chain = InheritanceChain::create($modelType->getModel()->getSourceClass());
+            $name = static::unionName($modelType->getName(), $schema->getConfig());
+            $union = ModelUnionType::create($modelType, $name);
+
+            $types = array_map(function ($class) use ($schema) {
+                return $schema->getConfig()->getTypeNameForClass($class);
+            }, $chain->getInheritance());
+
+            $types[] = $modelType->getName();
+
+            $union->setTypes($types);
+            $union->setTypeResolver([AbstractTypeResolver::class, 'resolveType']);
+            $schema->addUnion($union);
+        }
+    }
+
+    /**
+     * Changes all queries to use inheritance unions where applicable
+     * @throws SchemaBuilderException
+     */
+    public function applyUnions(): void
+    {
+        $schema = $this->getSchema();
+        $queries = [];
+        foreach ($schema->getQueryType()->getFields() as $field) {
+            if ($field instanceof ModelQuery) {
+                $queries[] = $field;
+            }
+        }
+        foreach ($schema->getModels() as $model) {
+            foreach ($model->getFields() as $field) {
+                if ($field instanceof ModelQuery) {
+                    $queries[] = $field;
+                }
+            }
+        }
+        foreach ($schema->getInterfaces() as $interface) {
+            if (!$interface instanceof ModelInterfaceType) {
+                continue;
+            }
+            foreach ($interface->getFields() as $field) {
+                if ($field instanceof ModelQuery) {
+                    $queries[] = $field;
+                }
+            }
+        }
+        /* @var ModelQuery $query */
+        foreach ($queries as $query) {
+            $typeName = $query->getNamedType();
+            $modelType = $schema->getModel($typeName);
+            // Type was customised. Ignore.
+            if (!$modelType) {
+                continue;
+            }
+            if (!$modelType->getModel() instanceof DataObjectModel) {
+                continue;
+            }
+
+            $unionName = static::unionName($modelType->getName(), $schema->getConfig());
+            if ($union = $schema->getUnion($unionName)) {
+                $query->setNamedType($unionName);
+            }
+        }
+    }
+
+    /**
+     * @param string $modelName
+     * @param SchemaConfig $schemaConfig
+     * @return string
+     * @throws SchemaBuilderException
+     */
+    public static function unionName(string $modelName, SchemaConfig $schemaConfig): string
+    {
+        $callable = $schemaConfig->get(
+            'inheritance.union_formatter',
+            [static:: class, 'defaultUnionFormatter']
+        );
+        return $callable($modelName);
+    }
+
+    /**
+     * @param string $modelName
+     * @return string
+     */
+    public static function defaultUnionFormatter(string $modelName): string
+    {
+        return $modelName . 'InheritanceUnion';
+    }
+
+
+    /**
+     * @return Schema
+     */
+    public function getSchema(): Schema
+    {
+        return $this->schema;
+    }
+
+    /**
+     * @param Schema $schema
+     * @return InheritanceUnionBuilder
+     */
+    public function setSchema(Schema $schema): InheritanceUnionBuilder
+    {
+        $this->schema = $schema;
+        return $this;
+    }
+
+
+}

--- a/src/Schema/DataObject/InheritanceUnionBuilder.php
+++ b/src/Schema/DataObject/InheritanceUnionBuilder.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Schema\DataObject;
 
-
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Field\ModelQuery;
@@ -50,6 +49,9 @@ class InheritanceUnionBuilder
         /* @var ModelInterfaceType $interface */
         foreach ($dataObjects as $modelType) {
             $chain = InheritanceChain::create($modelType->getModel()->getSourceClass());
+            if (!$chain->hasDescendants()) {
+                continue;
+            }
             $name = static::unionName($modelType->getName(), $schema->getConfig());
             $union = ModelUnionType::create($modelType, $name);
 
@@ -58,7 +60,11 @@ class InheritanceUnionBuilder
                     return null;
                 }
                 return $schema->getConfig()->getTypeNameForClass($class);
-            }, $chain->getInheritance()));
+            }, $chain->getDescendantModels()));
+
+            if (empty($types)) {
+                continue;
+            }
 
             $types[] = $modelType->getName();
 
@@ -159,6 +165,4 @@ class InheritanceUnionBuilder
         $this->schema = $schema;
         return $this;
     }
-
-
 }

--- a/src/Schema/DataObject/InterfaceBuilder.php
+++ b/src/Schema/DataObject/InterfaceBuilder.php
@@ -81,7 +81,6 @@ class InterfaceBuilder
 
         foreach ($interfaceStack as $ancestorInterface) {
             $modelType->addInterface($ancestorInterface->getName());
-            $interface->addInterface($ancestorInterface->getName());
         }
 
         $interfaceStack[] = $interface;
@@ -152,6 +151,9 @@ class InterfaceBuilder
             $interfaceName = static::interfaceName($modelType->getName(), $schema->getConfig());
             if ($interface = $schema->getInterface($interfaceName)) {
                 $query->setNamedType($interfaceName);
+                // Because the canonical type no longer appears in a query, we need to eagerly load
+                // it into the schema so it is discoverable. Helps with intellisense
+                $this->schema->eagerLoad($modelType->getName());
             }
         }
 

--- a/src/Schema/DataObject/InterfaceBuilder.php
+++ b/src/Schema/DataObject/InterfaceBuilder.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Schema\DataObject;
 
-
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Schema;
@@ -46,7 +45,8 @@ class InterfaceBuilder
      * @throws ReflectionException
      * @throws SchemaBuilderException
      */
-    public function createInterfaces(ModelType $modelType, array $interfaceStack = []): void {
+    public function createInterfaces(ModelType $modelType, array $interfaceStack = []): void
+    {
         $interface = ModelInterfaceType::create(
             $modelType->getModel(),
             self::interfaceName($modelType->getName(), $this->getSchema()->getConfig())
@@ -149,5 +149,4 @@ class InterfaceBuilder
     {
         return $modelName . 'Interface';
     }
-
 }

--- a/src/Schema/DataObject/InterfaceBuilder.php
+++ b/src/Schema/DataObject/InterfaceBuilder.php
@@ -53,7 +53,7 @@ class InterfaceBuilder
     public function createInterfaces(ModelType $modelType, array $interfaceStack = []): self
     {
         $interface = ModelInterfaceType::create(
-            $modelType->getModel(),
+            $modelType,
             self::interfaceName($modelType->getName(), $this->getSchema()->getConfig())
         )
             ->setTypeResolver([AbstractTypeResolver::class, 'resolveType']);
@@ -93,6 +93,8 @@ class InterfaceBuilder
                 $this->createInterfaces($childType, $interfaceStack);
             }
         }
+
+        return $this;
     }
 
     /**

--- a/src/Schema/DataObject/InterfaceBuilder.php
+++ b/src/Schema/DataObject/InterfaceBuilder.php
@@ -24,18 +24,20 @@ class InterfaceBuilder
 {
     use Injectable;
 
+    const BASE_INTERFACE_NAME = 'DataObject';
+
     /**
      * @var Schema
      */
     private $schema;
 
     /**
-     * InterfaceBuilder constructor.
+     * InterfaceBuilderTest constructor.
      * @param Schema $schema
      */
     public function __construct(Schema $schema)
     {
-        $this->schema = $schema;
+        $this->setSchema($schema);
     }
 
     /**
@@ -88,7 +90,7 @@ class InterfaceBuilder
         if (empty($commonFields)) {
             return;
         }
-        $baseInterface = InterfaceType::create('DataObject');
+        $baseInterface = InterfaceType::create(self::BASE_INTERFACE_NAME);
         foreach ($commonFields as $fieldName => $fieldType) {
             $baseInterface->addField(
                 FieldAccessor::singleton()->formatField($fieldName),
@@ -133,7 +135,7 @@ class InterfaceBuilder
     public static function interfaceName(string $modelName, SchemaConfig $schemaConfig): string
     {
         $callable = $schemaConfig->get(
-            'inheritance.interface_formatter',
+            'interfaceBuilder.name_formatter',
             [static:: class, 'defaultInterfaceFormatter']
         );
         return $callable($modelName);

--- a/src/Schema/DataObject/InterfaceBuilder.php
+++ b/src/Schema/DataObject/InterfaceBuilder.php
@@ -1,0 +1,151 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Schema\DataObject;
+
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
+use SilverStripe\GraphQL\Schema\Schema;
+use SilverStripe\GraphQL\Schema\SchemaConfig;
+use SilverStripe\GraphQL\Schema\Type\InterfaceType;
+use SilverStripe\GraphQL\Schema\Type\ModelInterfaceType;
+use SilverStripe\GraphQL\Schema\Type\ModelType;
+use ReflectionException;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * A schema-aware service for DataObject model types that emulates class inheritance
+ * by capturing groups of common fields into interfaces and applying one or many
+ * interfaces to concrete model types. Also creates a "base" interface for fields
+ * common to all DataObjects (i.e. "extends DataObject" pattern)
+ */
+class InterfaceBuilder
+{
+    use Injectable;
+
+    /**
+     * @var Schema
+     */
+    private $schema;
+
+    /**
+     * InterfaceBuilder constructor.
+     * @param Schema $schema
+     */
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * @param ModelType $modelType
+     * @param ModelInterfaceType[] $interfaceStack
+     * @throws ReflectionException
+     * @throws SchemaBuilderException
+     */
+    public function createInterfaces(ModelType $modelType, array $interfaceStack = []): void {
+        $interface = ModelInterfaceType::create(
+            $modelType->getModel(),
+            self::interfaceName($modelType->getName(), $this->getSchema()->getConfig())
+        );
+        $interface->setTypeResolver([AbstractTypeResolver::class, 'resolveType']);
+
+        // Start by adding all the fields in the model
+        foreach ($modelType->getFields() as $fieldObj) {
+            $clone = clone $fieldObj;
+            $interface->addField($fieldObj->getName(), $clone);
+        }
+
+        $this->getSchema()->addInterface($interface);
+
+        foreach ($interfaceStack as $ancestorInterface) {
+            $modelType->addInterface($ancestorInterface->getName());
+            $interface->addInterface($ancestorInterface->getName());
+        }
+
+        $interfaceStack[] = $interface;
+        $modelType->addInterface($interface->getName());
+
+        $chain = InheritanceChain::create($modelType->getModel()->getSourceClass());
+        foreach ($chain->getDirectDescendants() as $class) {
+            if ($childType = $this->getSchema()->getModelByClassName($class)) {
+                $this->createInterfaces($childType, $interfaceStack);
+            }
+        }
+    }
+
+    /**
+     * @return void
+     * @throws SchemaBuilderException
+     */
+    public function applyBaseInterface(): void
+    {
+        $commonFields = $this->getSchema()->getConfig()
+            ->getModelConfiguration('DataObject')
+            ->getBaseFields();
+
+        if (empty($commonFields)) {
+            return;
+        }
+        $baseInterface = InterfaceType::create('DataObject');
+        foreach ($commonFields as $fieldName => $fieldType) {
+            $baseInterface->addField(
+                FieldAccessor::singleton()->formatField($fieldName),
+                $fieldType
+            );
+        }
+        $baseInterface->setDescription('The common interface shared by all DataObject types');
+        $baseInterface->setTypeResolver([AbstractTypeResolver::class, 'resolveType']);
+        $this->getSchema()->addInterface($baseInterface);
+
+        $dataObjects = $this->getSchema()->getModelTypesFromClass(DataObject::class);
+        foreach ($dataObjects as $modelType) {
+            $modelType->addInterface($baseInterface->getName());
+        }
+    }
+
+    /**
+     * @return Schema
+     */
+    public function getSchema(): Schema
+    {
+        return $this->schema;
+    }
+
+    /**
+     * @param Schema $schema
+     * @return InterfaceBuilder
+     */
+    public function setSchema(Schema $schema): InterfaceBuilder
+    {
+        $this->schema = $schema;
+        return $this;
+    }
+
+
+    /**
+     * @param string $modelName
+     * @param SchemaConfig $schemaConfig
+     * @return string
+     * @throws SchemaBuilderException
+     */
+    public static function interfaceName(string $modelName, SchemaConfig $schemaConfig): string
+    {
+        $callable = $schemaConfig->get(
+            'inheritance.interface_formatter',
+            [static:: class, 'defaultInterfaceFormatter']
+        );
+        return $callable($modelName);
+    }
+
+    /**
+     * @param string $modelName
+     * @return string
+     */
+    public static function defaultInterfaceFormatter(string $modelName): string
+    {
+        return $modelName . 'Interface';
+    }
+
+}

--- a/src/Schema/DataObject/Plugin/Inheritance.php
+++ b/src/Schema/DataObject/Plugin/Inheritance.php
@@ -3,30 +3,22 @@
 
 namespace SilverStripe\GraphQL\Schema\DataObject\Plugin;
 
-use SilverStripe\GraphQL\QueryHandler\SchemaConfigProvider;
-use SilverStripe\GraphQL\Schema\DataObject\DataObjectModel;
-use SilverStripe\GraphQL\Schema\DataObject\FieldAccessor;
-use SilverStripe\GraphQL\Schema\DataObject\InheritanceChain;
+use SilverStripe\GraphQL\Schema\DataObject\InheritanceBuilder;
+use SilverStripe\GraphQL\Schema\DataObject\InheritanceUnionBuilder;
+use SilverStripe\GraphQL\Schema\DataObject\InterfaceBuilder;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
-use SilverStripe\GraphQL\Schema\Field\ModelField;
-use SilverStripe\GraphQL\Schema\Field\ModelQuery;
 use SilverStripe\GraphQL\Schema\Interfaces\PluginInterface;
 use SilverStripe\GraphQL\Schema\Interfaces\SchemaUpdater;
 use SilverStripe\GraphQL\Schema\Schema;
-use SilverStripe\GraphQL\Schema\SchemaConfig;
-use SilverStripe\GraphQL\Schema\Type\InterfaceType;
-use SilverStripe\GraphQL\Schema\Type\ModelInterfaceType;
-use SilverStripe\GraphQL\Schema\Type\ModelType;
-use SilverStripe\GraphQL\Schema\Type\ModelUnionType;
 use SilverStripe\ORM\DataObject;
 use ReflectionException;
-use Exception;
 
 /**
  * Adds inheritance fields to a DataObject type, and exposes its ancestry
  */
 class Inheritance implements PluginInterface, SchemaUpdater
 {
+
     const IDENTIFIER = 'inheritance';
 
     /**
@@ -46,461 +38,33 @@ class Inheritance implements PluginInterface, SchemaUpdater
     {
         $baseModels = [];
         $leafModels = [];
-        foreach (self::getDataObjectTypes($schema) as $modelType) {
+
+        $inheritance = InheritanceBuilder::create($schema);
+        $interfaces = InterfaceBuilder::create($schema);
+        $unions = InheritanceUnionBuilder::create($schema);
+
+        foreach ($schema->getModelTypesFromClass(DataObject::class) as $modelType) {
             $class = $modelType->getModel()->getSourceClass();
-            if (self::isBaseModel($class, $schema)) {
+            if ($inheritance->isBaseModel($class)) {
                 $baseModels[] = $modelType;
-            } else if (self::isLeafModel($class, $schema)) {
+            } else if ($inheritance->isLeafModel($class)) {
                 $leafModels[] = $modelType;
             }
         }
+
         foreach ($leafModels as $modelType) {
-            self::fillAncestry($schema, $modelType);
+            $inheritance->fillAncestry($modelType);
         }
+
         foreach ($baseModels as $modelType) {
-            self::fillDescendants($schema, $modelType);
-            self::createInterfaces($schema, $modelType);
+            $inheritance->fillDescendants($modelType);
+            $interfaces->createInterfaces($modelType);
         }
 
-        self::applyBaseInterface($schema);
+        $interfaces->applyBaseInterface();
 
-        self::createUnions($schema);
-        self::applyUnions($schema);
-
+        $unions->createUnions();
+        $unions->applyUnions();
     }
 
-    /**
-     * @param $obj
-     * @param $context
-     * @return string
-     * @throws SchemaBuilderException
-     * @throws Exception
-     */
-    public static function resolveType($obj, $context): string
-    {
-        $class = get_class($obj);
-        $schemaContext = SchemaConfigProvider::get($context);
-
-        while ($class && !$schemaContext->hasModel($class)) {
-            if ($class === DataObject::class) {
-                throw new Exception(sprintf(
-                    'No models were registered in the ancestry of %s',
-                    get_class($obj)
-                ));
-            }
-            $class = get_parent_class($class);
-            Schema::invariant(
-                $class,
-                'Could not resolve type for %s.',
-                get_class($obj)
-            );
-        }
-        return $schemaContext->getTypeNameForClass($class);
-    }
-
-    /**
-     * @param string $modelName
-     * @param SchemaConfig $schemaConfig
-     * @return string
-     */
-    public static function unionName(string $modelName, SchemaConfig $schemaConfig): string
-    {
-        $callable = $schemaConfig->get(
-            'inheritance.union_formatter',
-            [static:: class, 'defaultUnionFormatter']
-        );
-        return $callable($modelName);
-    }
-
-    /**
-     * @param string $modelName
-     * @param SchemaConfig $schemaConfig
-     * @return string
-     */
-    public static function interfaceName(string $modelName, SchemaConfig $schemaConfig): string
-    {
-        $callable = $schemaConfig->get(
-            'inheritance.interface_formatter',
-            [static:: class, 'defaultInterfaceFormatter']
-        );
-        return $callable($modelName);
-    }
-
-    /**
-     * @param string $modelName
-     * @return string
-     */
-    public static function defaultUnionFormatter(string $modelName): string
-    {
-        return $modelName . 'InheritanceUnion';
-    }
-
-    /**
-     * @param string $modelName
-     * @return string
-     */
-    public static function defaultInterfaceFormatter(string $modelName): string
-    {
-        return $modelName . 'Interface';
-    }
-
-    /**
-     * @param Schema $schema
-     * @return ModelType[]
-     */
-    private static function getDataObjectTypes(Schema $schema): array
-    {
-        return array_filter($schema->getModels(), function (ModelType $modelType) {
-            $class = $modelType->getModel()->getSourceClass();
-            return is_subclass_of($class, DataObject::class);
-        });
-    }
-
-    /**
-     * @param Schema $schema
-     * @return array
-     */
-    private static function getDataObjectInterfaces(Schema $schema): array
-    {
-        return array_filter($schema->getInterfaces(), function (InterfaceType $interface) {
-            if ($interface instanceof ModelInterfaceType) {
-                $class = $interface->getModel()->getSourceClass();
-                return is_subclass_of($class, DataObject::class);
-            }
-            return false;
-        });
-    }
-
-    /**
-     * @param Schema $schema
-     * @param ModelType $modelType
-     * @throws SchemaBuilderException
-     */
-    private static function fillAncestry(Schema $schema, ModelType $modelType): void
-    {
-        $chain = InheritanceChain::create($modelType->getModel()->getSourceClass());
-        $ancestors = $chain->getAncestralModels();
-        if (empty($ancestors)) {
-            return;
-        }
-        $parent = $ancestors[0];
-        $parentModel = $schema->findOrMakeModel($parent);
-        // Merge descendant fields up into the ancestor
-        foreach ($modelType->getFields() as $fieldObj) {
-            // If the field already exists on the ancestor, skip it
-            if ($parentModel->getFieldByName($fieldObj->getName())) {
-                continue;
-            }
-            $fieldName = $fieldObj instanceof ModelField
-                ? $fieldObj->getPropertyName()
-                : $fieldObj->getName();
-            // If the field is unique to the descendant, skip it.
-            if ($parentModel->getModel()->hasField($fieldName)) {
-                $clone = clone $fieldObj;
-                $parentModel->addField($fieldObj->getName(), $clone);
-            }
-        }
-        self::fillAncestry($schema, $parentModel);
-    }
-
-    /**
-     * @param Schema $schema
-     * @param ModelType $modelType
-     * @throws ReflectionException
-     * @throws SchemaBuilderException
-     */
-    private static function fillDescendants(Schema $schema, ModelType $modelType)
-    {
-        $chain = InheritanceChain::create($modelType->getModel()->getSourceClass());
-        $descendants = $chain->getDirectDescendants();
-        if (empty($descendants)) {
-            return;
-        }
-        foreach ($descendants as $descendant) {
-            $descendantModel = $schema->getModelByClassName($descendant);
-            if ($descendantModel) {
-                foreach ($modelType->getFields() as $fieldObj) {
-                    if ($descendantModel->getFieldByName($fieldObj->getName())) {
-                        continue;
-                    }
-                    $clone = clone $fieldObj;
-                    $descendantModel->addField($fieldObj->getName(), $clone);
-                }
-                self::fillDescendants($schema, $descendantModel);
-            }
-        }
-    }
-
-    /**
-     * @param Schema $schema
-     * @param ModelType $modelType
-     * @param ModelInterfaceType[] $interfaceStack
-     * @throws ReflectionException
-     * @throws SchemaBuilderException
-     */
-    private static function createInterfaces(
-        Schema $schema,
-        ModelType $modelType,
-        array $interfaceStack = []
-    ): void {
-
-        $interface = ModelInterfaceType::create(
-            $modelType->getModel(),
-            self::interfaceName($modelType->getName(), $schema->getConfig())
-        );
-        $interface->setTypeResolver([static::class, 'resolveType']);
-
-        // Start by adding all the fields in the model
-        foreach ($modelType->getFields() as $fieldObj) {
-            $clone = clone $fieldObj;
-            $interface->addField($fieldObj->getName(), $clone);
-        }
-
-        // Remove any fields that are exposed in ancestors, ensuring
-        // each interface only contains "native" fields
-        foreach ($interfaceStack as $ancestorInterface) {
-            foreach ($ancestorInterface->getFields() as $fieldObj) {
-                $interface->removeField($fieldObj->getName());
-            }
-        }
-
-        // If the interface has no fields, just skip it and proceed down the tree
-        if (!empty($interface->getFields())) {
-            $schema->addInterface($interface);
-            $interfaceStack[] = $interface;
-        }
-        foreach ($interfaceStack as $interface) {
-            $modelType->addInterface($interface->getName());
-        }
-
-        $chain = InheritanceChain::create($modelType->getModel()->getSourceClass());
-        foreach ($chain->getDirectDescendants() as $class) {
-            if ($childType = $schema->getModelByClassName($class)) {
-                self::createInterfaces($schema, $childType, $interfaceStack);
-            }
-        }
-    }
-
-    /**
-     * @param Schema $schema
-     * @return void
-     */
-    private static function applyBaseInterface(Schema $schema): void
-    {
-        $commonFields = $schema->getConfig()
-            ->getModelConfiguration('DataObject')
-            ->getBaseFields();
-
-        if (empty($commonFields)) {
-            return;
-        }
-        $baseInterface = InterfaceType::create('DataObject');
-        foreach ($commonFields as $fieldName => $fieldType) {
-            $baseInterface->addField(
-                FieldAccessor::singleton()->formatField($fieldName),
-                $fieldType
-            );
-        }
-        $baseInterface->setDescription('The common interface shared by all DataObject types');
-        $baseInterface->setTypeResolver([static::class, 'resolveType']);
-        $schema->addInterface($baseInterface);
-
-        foreach (self::getDataObjectTypes($schema) as $modelType) {
-            $modelType->addInterface($baseInterface->getName());
-        }
-    }
-
-    /**
-     * @param Schema $schema
-     */
-    private static function createUnions(Schema $schema)
-    {
-        /* @var ModelInterfaceType $interface */
-        foreach (self::getDataObjectTypes($schema) as $modelType) {
-            $chain = InheritanceChain::create($modelType->getModel()->getSourceClass());
-
-            $name = static::unionName($modelType->getName(), $schema->getConfig());
-            $union = ModelUnionType::create($modelType, $name);
-
-            $types = array_map(function ($class) use ($schema) {
-                return $schema->getConfig()->getTypeNameForClass($class);
-            }, $chain->getInheritance());
-
-            $types[] = $modelType->getName();
-
-            $union->setTypes($types);
-            $union->setTypeResolver([static::class, 'resolveType']);
-            $schema->addUnion($union);
-        }
-    }
-
-    /**
-     * @param Schema $schema
-     * @throws SchemaBuilderException
-     */
-    private static function applyUnions(Schema $schema): void
-    {
-        $queries = [];
-        foreach ($schema->getQueryType()->getFields() as $field) {
-            if ($field instanceof ModelQuery) {
-                $queries[] = $field;
-            }
-        }
-        foreach ($schema->getModels() as $model) {
-            foreach ($model->getFields() as $field) {
-                if ($field instanceof ModelQuery) {
-                    $queries[] = $field;
-                }
-            }
-        }
-        foreach ($schema->getInterfaces() as $interface) {
-            if (!$interface instanceof ModelInterfaceType) {
-                continue;
-            }
-            foreach ($interface->getFields() as $field) {
-                if ($field instanceof ModelQuery) {
-                    $queries[] = $field;
-                }
-            }
-        }
-        /* @var ModelQuery $query */
-        foreach ($queries as $query) {
-            $typeName = $query->getNamedType();
-            $modelType = $schema->getModel($typeName);
-            // Type was customised. Ignore.
-            if (!$modelType) {
-                continue;
-            }
-            if (!$modelType->getModel() instanceof DataObjectModel) {
-                continue;
-            }
-
-            $unionName = static::unionName($modelType->getName(), $schema->getConfig());
-            if ($union = $schema->getUnion($unionName)) {
-                $query->setNamedType($unionName);
-            }
-        }
-    }
-
-    /**
-     * @param Schema $schema
-     * @throws SchemaBuilderException
-     */
-    private static function applyInterfaces(Schema $schema): void
-    {
-        $queries = [];
-        foreach ($schema->getQueryType()->getFields() as $field) {
-            if ($field instanceof ModelQuery) {
-                $queries[] = $field;
-            }
-        }
-        foreach ($schema->getModels() as $model) {
-            foreach ($model->getFields() as $field) {
-                if ($field instanceof ModelQuery) {
-                    $queries[] = $field;
-                }
-            }
-        }
-        foreach ($schema->getInterfaces() as $interface) {
-            if (!$interface instanceof ModelInterfaceType) {
-                continue;
-            }
-            foreach ($interface->getFields() as $field) {
-                if ($field instanceof ModelQuery) {
-                    $queries[] = $field;
-                }
-            }
-        }
-        /* @var ModelQuery $query */
-        foreach ($queries as $query) {
-            $typeName = $query->getNamedType();
-            $modelType = $schema->getModel($typeName);
-            // Type was customised. Ignore.
-            if (!$modelType) {
-                continue;
-            }
-            if (!$modelType->getModel() instanceof DataObjectModel) {
-                continue;
-            }
-
-            $interfaceName = static::interfaceName($modelType->getName(), $schema->getConfig());
-            if ($interface = $schema->getInterface($interfaceName)) {
-                $query->setNamedType($interfaceName);
-            }
-        }
-    }
-
-    /**
-     * @param string $class
-     * @param Schema $schema
-     * @return bool
-     */
-    private static function isBaseModel(string $class, Schema $schema): bool
-    {
-        $chain = InheritanceChain::create($class);
-        if ($chain->getBaseClass() === $class) {
-            return true;
-        }
-        foreach ($chain->getAncestralModels() as $class) {
-            if ($schema->getModelByClassName($class)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * @param string $class
-     * @return bool
-     * @throws ReflectionException
-     */
-    private static function isStandaloneModel(string $class): bool
-    {
-        return !InheritanceChain::create($class)->hasInheritance();
-    }
-
-    /**
-     * @param Schema $schema
-     * @param string $class
-     * @return bool
-     */
-    private static function isReadable(Schema $schema, string $class): bool
-    {
-        $type = $schema->getModelByClassName($class);
-        if (!$type) {
-            return false;
-        }
-        foreach ($type->getOperations() as $operation) {
-            if ($operation instanceof ModelQuery) {
-                return true;
-            }
-        }
-        // Check for nested queries that expose the object
-        foreach ($schema->getModels() as $model) {
-            foreach ($model->getFields() as $field) {
-                if ($field->getNamedType() === $type->getName()) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * @param string $class
-     * @param Schema $schema
-     * @return bool
-     * @throws ReflectionException
-     */
-    private static function isLeafModel(string $class, Schema $schema): bool
-    {
-        $chain = InheritanceChain::create($class);
-        foreach ($chain->getDescendantModels() as $class) {
-            if ($schema->getModelByClassName($class)) {
-                return false;
-            }
-        }
-        return true;
-    }
 }

--- a/src/Schema/DataObject/Plugin/Inheritance.php
+++ b/src/Schema/DataObject/Plugin/Inheritance.php
@@ -47,7 +47,7 @@ class Inheritance implements PluginInterface, SchemaUpdater
             $class = $modelType->getModel()->getSourceClass();
             if ($inheritance->isBaseModel($class)) {
                 $baseModels[] = $modelType;
-            } else if ($inheritance->isLeafModel($class)) {
+            } elseif ($inheritance->isLeafModel($class)) {
                 $leafModels[] = $modelType;
             }
         }
@@ -66,5 +66,4 @@ class Inheritance implements PluginInterface, SchemaUpdater
         $unions->createUnions();
         $unions->applyUnions();
     }
-
 }

--- a/src/Schema/DataObject/Plugin/InheritedPlugins.php
+++ b/src/Schema/DataObject/Plugin/InheritedPlugins.php
@@ -36,6 +36,7 @@ class InheritedPlugins implements ModelTypePlugin
      */
     public function apply(ModelType $type, Schema $schema, array $config = []): void
     {
+        return;
         $sourceClass = $type->getModel()->getSourceClass();
         Schema::invariant(
             is_subclass_of($sourceClass, DataObject::class),

--- a/src/Schema/DataObject/Plugin/Paginator.php
+++ b/src/Schema/DataObject/Plugin/Paginator.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\GraphQL\Schema\DataObject\Plugin;
 
 use GraphQL\Type\Definition\ResolveInfo;
+use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\ORM\Limitable;
 use SilverStripe\GraphQL\Schema\Plugin\PaginationPlugin;
 use Closure;
@@ -36,13 +37,19 @@ class Paginator extends PaginationPlugin
             if ($list === null) {
                 return null;
             }
+
             if (!$list instanceof Limitable) {
-                return static::createPaginationResult($list, $list, $maxLimit, 0);
+                Schema::invariant(
+                    !isset($list['nodes']),
+                    'List on field %s has already been paginated. Was the plugin executed twice?',
+                    $info->fieldName
+                );
+                return static::createPaginationResult(count($list), $list, $maxLimit, 0);
             }
 
+            $total = $list->count();
             $offset = $args['offset'];
             $limit = $args['limit'];
-            $total = $list->count();
 
             $limit = min($limit, $maxLimit);
 

--- a/src/Schema/DataObject/Plugin/QueryCollector.php
+++ b/src/Schema/DataObject/Plugin/QueryCollector.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Schema\DataObject\Plugin;
 
-
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Field\ModelField;

--- a/src/Schema/DataObject/Plugin/QueryCollector.php
+++ b/src/Schema/DataObject/Plugin/QueryCollector.php
@@ -1,0 +1,58 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Schema\DataObject\Plugin;
+
+
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
+use SilverStripe\GraphQL\Schema\Field\ModelField;
+use SilverStripe\GraphQL\Schema\Field\ModelQuery;
+use SilverStripe\GraphQL\Schema\Schema;
+use SilverStripe\GraphQL\Schema\Type\ModelInterfaceType;
+use Generator;
+
+class QueryCollector
+{
+    use Injectable;
+
+    /**
+     * @var Schema
+     */
+    private $schema;
+
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+    }
+
+    /**
+     * @return Generator
+     * @throws SchemaBuilderException
+     */
+    public function collectQueries(): Generator
+    {
+        foreach ($this->schema->getQueryType()->getFields() as $field) {
+            if ($field instanceof ModelQuery) {
+                yield $field;
+            }
+        }
+        foreach ($this->schema->getModels() as $model) {
+            foreach ($model->getFields() as $field) {
+                if ($field instanceof ModelField && $field->getModelType()) {
+                    yield $field;
+                }
+            }
+        }
+        foreach ($this->schema->getInterfaces() as $interface) {
+            if (!$interface instanceof ModelInterfaceType) {
+                continue;
+            }
+            foreach ($interface->getFields() as $field) {
+                if ($field instanceof ModelField && $field->getModelType()) {
+                    yield $field;
+                }
+            }
+        }
+    }
+}

--- a/src/Schema/DataObject/Plugin/QueryFilter/QueryFilter.php
+++ b/src/Schema/DataObject/Plugin/QueryFilter/QueryFilter.php
@@ -99,6 +99,9 @@ class QueryFilter extends AbstractQueryFilterPlugin
                 ));
             }
             $filterArgs = $args[$fieldName] ?? [];
+            if (empty($filterArgs)) {
+                return $list;
+            }
             /* @var FilterRegistryInterface $registry */
             $registry = Injector::inst()->get(FilterRegistryInterface::class);
             $paths = NestedInputBuilder::buildPathsFromArgs($filterArgs);

--- a/src/Schema/DataObject/Plugin/QueryFilter/QueryFilter.php
+++ b/src/Schema/DataObject/Plugin/QueryFilter/QueryFilter.php
@@ -7,7 +7,7 @@ use SilverStripe\GraphQL\Schema\DataObject\FieldAccessor;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Type\Type;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\GraphQL\QueryHandler\SchemaContextProvider;
+use SilverStripe\GraphQL\QueryHandler\SchemaConfigProvider;
 use SilverStripe\GraphQL\Schema\Field\Field;
 use SilverStripe\GraphQL\Schema\Field\ModelField;
 use SilverStripe\GraphQL\Schema\Field\ModelQuery;
@@ -90,12 +90,12 @@ class QueryFilter extends AbstractQueryFilterPlugin
             if ($list === null) {
                 return null;
             }
-            $schemaContext = SchemaContextProvider::get($context);
+            $schemaContext = SchemaConfigProvider::get($context);
             if (!$schemaContext) {
                 throw new Exception(sprintf(
                     'No schemaContext was present in the resolver context. Make sure the %s class is added
                     to the query handler',
-                    SchemaContextProvider::class
+                    SchemaConfigProvider::class
                 ));
             }
             $filterArgs = $args[$fieldName] ?? [];

--- a/src/Schema/DataObject/Plugin/QuerySort.php
+++ b/src/Schema/DataObject/Plugin/QuerySort.php
@@ -5,7 +5,7 @@ namespace SilverStripe\GraphQL\Schema\DataObject\Plugin;
 
 use SilverStripe\GraphQL\Schema\DataObject\FieldAccessor;
 use SilverStripe\GraphQL\Schema\Type\Type;
-use SilverStripe\GraphQL\QueryHandler\SchemaContextProvider;
+use SilverStripe\GraphQL\QueryHandler\SchemaConfigProvider;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Field\Field;
 use SilverStripe\GraphQL\Schema\Field\ModelField;
@@ -108,12 +108,12 @@ class QuerySort extends AbstractQuerySortPlugin
             }
             $filterArgs = $args[$fieldName] ?? [];
             $paths = NestedInputBuilder::buildPathsFromArgs($filterArgs);
-            $schemaContext = SchemaContextProvider::get($context);
+            $schemaContext = SchemaConfigProvider::get($context);
             if (!$schemaContext) {
                 throw new Exception(sprintf(
                     'No schemaContext was present in the resolver context. Make sure the %s class is added
                     to the query handler',
-                    SchemaContextProvider::class
+                    SchemaConfigProvider::class
                 ));
             }
 

--- a/src/Schema/DataObject/ReadCreator.php
+++ b/src/Schema/DataObject/ReadCreator.php
@@ -36,6 +36,7 @@ class ReadCreator implements OperationCreator
         $plugins = $config['plugins'] ?? [];
         $queryName = $config['name'] ?? null;
         $resolver = $config['resolver'] ?? null;
+        $useUnion = $config['preferUnion'] ?? true;
 
         if (!$queryName) {
             $pluraliser = $model->getSchemaConfig()->getPluraliser();

--- a/src/Schema/DataObject/ReadCreator.php
+++ b/src/Schema/DataObject/ReadCreator.php
@@ -36,7 +36,6 @@ class ReadCreator implements OperationCreator
         $plugins = $config['plugins'] ?? [];
         $queryName = $config['name'] ?? null;
         $resolver = $config['resolver'] ?? null;
-        $useUnion = $config['preferUnion'] ?? true;
 
         if (!$queryName) {
             $pluraliser = $model->getSchemaConfig()->getPluraliser();

--- a/src/Schema/DataObject/Resolver.php
+++ b/src/Schema/DataObject/Resolver.php
@@ -10,6 +10,7 @@ use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\SS_List;
+
 /**
  * Generic resolver for DataObjects
  */
@@ -25,6 +26,7 @@ class Resolver
      */
     public static function resolve($obj, $args = [], $context = [], ?ResolveInfo $info = null)
     {
+
         $fieldName = $info->fieldName;
         $context = SchemaConfigProvider::get($context);
         $fieldName = $context->mapFieldByClassName(get_class($obj), $fieldName);

--- a/src/Schema/DataObject/Resolver.php
+++ b/src/Schema/DataObject/Resolver.php
@@ -4,6 +4,7 @@
 namespace SilverStripe\GraphQL\Schema\DataObject;
 
 use GraphQL\Type\Definition\ResolveInfo;
+use SilverStripe\GraphQL\QueryHandler\SchemaConfigProvider;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
@@ -25,7 +26,7 @@ class Resolver
     public static function resolve($obj, $args = [], $context = [], ?ResolveInfo $info = null)
     {
         $fieldName = $info->fieldName;
-        $context = SchemaContextProvider::get($context);
+        $context = SchemaConfigProvider::get($context);
         $fieldName = $context->mapFieldByClassName(get_class($obj), $fieldName);
         $result = $fieldName ? FieldAccessor::singleton()->accessField($obj, $fieldName[1]) : null;
         if ($result instanceof DBField) {

--- a/src/Schema/DataObject/Resolver.php
+++ b/src/Schema/DataObject/Resolver.php
@@ -22,7 +22,7 @@ class Resolver
      * @return array|bool|int|mixed|DataList|DataObject|DBField|SS_List|string|null
      * @throws SchemaBuilderException
      */
-    public static function resolve($obj, array $args = [], array $context = [], ?ResolveInfo $info = null)
+    public static function resolve($obj, $args = [], $context = [], ?ResolveInfo $info = null)
     {
         $fieldName = $info->fieldName;
         $context = SchemaContextProvider::get($context);

--- a/src/Schema/DataObject/Resolver.php
+++ b/src/Schema/DataObject/Resolver.php
@@ -4,15 +4,11 @@
 namespace SilverStripe\GraphQL\Schema\DataObject;
 
 use GraphQL\Type\Definition\ResolveInfo;
-use SilverStripe\GraphQL\QueryHandler\SchemaContextProvider;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
-use SilverStripe\GraphQL\Schema\SchemaConfig;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
-use Closure;
 use SilverStripe\ORM\SS_List;
-
 /**
  * Generic resolver for DataObjects
  */

--- a/src/Schema/DataObject/UpdateCreator.php
+++ b/src/Schema/DataObject/UpdateCreator.php
@@ -143,7 +143,7 @@ class UpdateCreator implements OperationCreator, InputTypeProvider
             if (!$fieldObj) {
                 continue;
             }
-            $type = $fieldObj->getType();
+            $type = $fieldObj->getNamedType();
             // No nested input types... yet
             if ($type && Schema::isInternalType($type)) {
                 $fieldMap[$fieldName] = $type;

--- a/src/Schema/DataObject/UpdateCreator.php
+++ b/src/Schema/DataObject/UpdateCreator.php
@@ -8,7 +8,7 @@ use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\GraphQL\QueryHandler\QueryHandler;
-use SilverStripe\GraphQL\QueryHandler\SchemaContextProvider;
+use SilverStripe\GraphQL\QueryHandler\SchemaConfigProvider;
 use SilverStripe\GraphQL\QueryHandler\UserContextProvider;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Field\ModelMutation;
@@ -80,12 +80,12 @@ class UpdateCreator implements OperationCreator, InputTypeProvider
             if (!$dataClass) {
                 return null;
             }
-            $schema = SchemaContextProvider::get($context);
+            $schema = SchemaConfigProvider::get($context);
             Schema::invariant(
                 $schema,
                 'Could not access schema in resolver for %s. Did you not add the %s context provider?',
                 __CLASS__,
-                SchemaContextProvider::class
+                SchemaConfigProvider::class
             );
             $fieldName = FieldAccessor::formatField('ID');
             $input = $args['input'];

--- a/src/Schema/Exception/ResolverFailure.php
+++ b/src/Schema/Exception/ResolverFailure.php
@@ -21,19 +21,19 @@ class ResolverFailure extends Exception
         $args = $resolverArgs[1] ?? null;
         $info = $resolverArgs[3] ?? null;
         $message = sprintf(
-            'Failed to resolve field %s on %s.\n\n
-            Path: %s)\n\n
+            'Failed to resolve field %s returning %s.\n\n
+            Got error: %s\n\n
+            Path: %s\n\n
             Resolver %s failed in execution chain:\n\n
             %s\n\n
-            Args: %s\n\n
-            Got error: %s',
+            Args: %s\n\n',
             $this->fieldName($info),
             $this->returnType($info),
+            $error,
             $this->path($info),
             $this->resolver($callable),
             $this->executionChain($info),
-            $this->args($args),
-            $error
+            $this->args($args)
         );
         parent::__construct($message);
     }

--- a/src/Schema/Field/Field.php
+++ b/src/Schema/Field/Field.php
@@ -380,8 +380,22 @@ class Field implements
     }
 
     /**
+     * [MyType!]! becomes [MyNewType!]!
+     * @param string $name
+     * @return $this
+     * @throws SchemaBuilderException
+     */
+    public function setNamedType(string $name): self
+    {
+        $currentType = $this->getType();
+        $newType = preg_replace('/[A-Za-z_]+/', $name, $currentType);
+        return $this->setType($newType);
+    }
+
+    /**
      * @param string|null $typeName
      * @return EncodedResolver
+     * @throws SchemaBuilderException
      */
     public function getEncodedResolver(?string $typeName = null): EncodedResolver
     {

--- a/src/Schema/Field/Field.php
+++ b/src/Schema/Field/Field.php
@@ -388,7 +388,7 @@ class Field implements
     public function setNamedType(string $name): self
     {
         $currentType = $this->getType();
-        $newType = preg_replace('/[A-Za-z_]+/', $name, $currentType);
+        $newType = preg_replace('/[A-Za-z_0-9]+/', $name, $currentType);
         return $this->setType($newType);
     }
 

--- a/src/Schema/Field/ModelField.php
+++ b/src/Schema/Field/ModelField.php
@@ -94,6 +94,10 @@ class ModelField extends Field
      */
     public function getModelType(): ?ModelType
     {
+        $type = $this->getNamedType();
+        if (Schema::isInternalType($type)) {
+            return null;
+        }
         $model = $this->getModel()->getModelTypeForField($this->getName());
         if ($model) {
             $config = [];

--- a/src/Schema/Interfaces/BaseFieldsProvider.php
+++ b/src/Schema/Interfaces/BaseFieldsProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Schema\Interfaces;
+
+/**
+ * Defines a model that provides required fields for all the types it creates
+ */
+interface BaseFieldsProvider
+{
+    /**
+     * Fields that must appear on all implementations
+     * @return array
+     */
+    public function getBaseFields(): array;
+}

--- a/src/Schema/Interfaces/SchemaModelInterface.php
+++ b/src/Schema/Interfaces/SchemaModelInterface.php
@@ -74,5 +74,4 @@ interface SchemaModelInterface
      * @return string
      */
     public function getPropertyForField(string $field): string;
-
 }

--- a/src/Schema/Interfaces/SchemaModelInterface.php
+++ b/src/Schema/Interfaces/SchemaModelInterface.php
@@ -74,4 +74,5 @@ interface SchemaModelInterface
      * @return string
      */
     public function getPropertyForField(string $field): string;
+
 }

--- a/src/Schema/Interfaces/SchemaUpdater.php
+++ b/src/Schema/Interfaces/SchemaUpdater.php
@@ -11,5 +11,5 @@ use SilverStripe\GraphQL\Schema\Schema;
  */
 interface SchemaUpdater
 {
-    public static function updateSchema(Schema $schema): void;
+    public static function updateSchema(Schema $schem, array $config = []): void;
 }

--- a/src/Schema/Interfaces/SchemaUpdater.php
+++ b/src/Schema/Interfaces/SchemaUpdater.php
@@ -11,5 +11,9 @@ use SilverStripe\GraphQL\Schema\Schema;
  */
 interface SchemaUpdater
 {
-    public static function updateSchema(Schema $schema): void;
+    /**
+     * @param Schema $schema
+     * @param array $config
+     */
+    public static function updateSchema(Schema $schema, array $config = []): void;
 }

--- a/src/Schema/Interfaces/SchemaUpdater.php
+++ b/src/Schema/Interfaces/SchemaUpdater.php
@@ -11,5 +11,5 @@ use SilverStripe\GraphQL\Schema\Schema;
  */
 interface SchemaUpdater
 {
-    public static function updateSchema(Schema $schem, array $config = []): void;
+    public static function updateSchema(Schema $schema): void;
 }

--- a/src/Schema/Plugin/AbstractQueryFilterPlugin.php
+++ b/src/Schema/Plugin/AbstractQueryFilterPlugin.php
@@ -85,11 +85,13 @@ abstract class AbstractQueryFilterPlugin implements SchemaUpdater, ModelQueryPlu
             return;
         }
         $query->addArg($this->getFieldName(), $builder->getRootType()->getName());
+        $canonicalType = $schema->getCanonicalType($query->getNamedType());
+        $rootType = $canonicalType ? $canonicalType->getName() : $query->getNamedType();
         $query->addResolverAfterware(
             $this->getResolver($config),
             [
                 'fieldName' => $this->getFieldName(),
-                'rootType' => $query->getNamedType(),
+                'rootType' => $rootType,
             ]
         );
     }

--- a/src/Schema/Plugin/AbstractQueryFilterPlugin.php
+++ b/src/Schema/Plugin/AbstractQueryFilterPlugin.php
@@ -46,9 +46,10 @@ abstract class AbstractQueryFilterPlugin implements SchemaUpdater, ModelQueryPlu
     /**
      * Creates all the { eq: String, lte: String }, { eq: Int, lte: Int } etc types for comparisons
      * @param Schema $schema
+     * @param array $config
      * @throws SchemaBuilderException
      */
-    public static function updateSchema(Schema $schema): void
+    public static function updateSchema(Schema $schema, array $config = []): void
     {
         /* @var FieldFilterRegistry $registry */
         $registry = Injector::inst()->get(FilterRegistryInterface::class);

--- a/src/Schema/Plugin/AbstractQuerySortPlugin.php
+++ b/src/Schema/Plugin/AbstractQuerySortPlugin.php
@@ -47,11 +47,13 @@ abstract class AbstractQuerySortPlugin implements SchemaUpdater, ModelQueryPlugi
             return;
         }
         $query->addArg($this->getFieldName(), $builder->getRootType()->getName());
+        $canonicalType = $schema->getCanonicalType($query->getNamedType());
+        $rootType = $canonicalType ? $canonicalType->getName() : $query->getNamedType();
         $query->addResolverAfterware(
             $this->getResolver($config),
             [
                 'fieldName' => $this->getFieldName(),
-                'rootType' => $query->getNamedType(),
+                'rootType' => $rootType,
             ]
         );
     }

--- a/src/Schema/Plugin/AbstractQuerySortPlugin.php
+++ b/src/Schema/Plugin/AbstractQuerySortPlugin.php
@@ -77,8 +77,9 @@ abstract class AbstractQuerySortPlugin implements SchemaUpdater, ModelQueryPlugi
 
     /**
      * @param Schema $schema
+     * @param array $config
      */
-    public static function updateSchema(Schema $schema): void
+    public static function updateSchema(Schema $schema, array $config = []): void
     {
         $type = Enum::create(
             'SortDirection',

--- a/src/Schema/Plugin/PaginationPlugin.php
+++ b/src/Schema/Plugin/PaginationPlugin.php
@@ -69,9 +69,10 @@ class PaginationPlugin implements FieldPlugin, SchemaUpdater
 
     /**
      * @param Schema $schema
+     * @param array $config
      * @throws SchemaBuilderException
      */
-    public static function updateSchema(Schema $schema): void
+    public static function updateSchema(Schema $schema, array $config = []): void
     {
         // Create the PageInfo type, which is universal
         $pageinfoType = Type::create('PageInfo')

--- a/src/Schema/Plugin/SortPlugin.php
+++ b/src/Schema/Plugin/SortPlugin.php
@@ -47,10 +47,11 @@ class SortPlugin implements FieldPlugin, SchemaUpdater
 
     /**
      * @param Schema $schema
+     * @param array $config
      */
-    public static function updateSchema(Schema $schema): void
+    public static function updateSchema(Schema $schema, array $config = []): void
     {
-        AbstractQuerySortPlugin::updateSchema($schema);
+        AbstractQuerySortPlugin::updateSchema($schema, $config);
     }
 
     /**

--- a/src/Schema/Plugin/SortPlugin.php
+++ b/src/Schema/Plugin/SortPlugin.php
@@ -5,7 +5,7 @@ namespace SilverStripe\GraphQL\Schema\Plugin;
 
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
-use SilverStripe\GraphQL\QueryHandler\SchemaContextProvider;
+use SilverStripe\GraphQL\QueryHandler\SchemaConfigProvider;
 use SilverStripe\GraphQL\Schema\DataObject\FieldAccessor;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Field\Field;

--- a/src/Schema/Resolver/JSONResolver.php
+++ b/src/Schema/Resolver/JSONResolver.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Schema\Resolver;
 
-
 class JSONResolver
 {
     /**
@@ -32,6 +31,4 @@ class JSONResolver
     {
         return $ast->value;
     }
-
-
 }

--- a/src/Schema/Resolver/JSONResolver.php
+++ b/src/Schema/Resolver/JSONResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Schema\Resolver;
+
+
+class JSONResolver
+{
+    /**
+     * @param $value
+     * @return object
+     */
+    public static function serialise($value): object
+    {
+        return (object) $value;
+    }
+
+    /**
+     * @param $value
+     * @return array
+     */
+    public static function parseValue($value): array
+    {
+        return (array) $value;
+    }
+
+    /**
+     * @param $ast
+     * @return mixed
+     */
+    public static function parseLiteral($ast)
+    {
+        return $ast->value;
+    }
+
+
+}

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -725,6 +725,18 @@ class Schema implements ConfigurationApplier
         return null;
     }
 
+    /**
+     * Gets all the models that were generated from a given ancestor, e.g. DataObject
+     * @param string $class
+     * @return ModelType[]
+     */
+    public function getModelTypesFromClass(string $class): array
+    {
+        return array_filter($this->getModels(), function (ModelType $modelType) use ($class) {
+            $source = $modelType->getModel()->getSourceClass();
+            return $source === $class || is_subclass_of($source, $class);
+        });
+    }
 
     /**
      * @return Type[]

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -664,6 +664,17 @@ class Schema implements ConfigurationApplier
     }
 
     /**
+     * @param string $type
+     * @return $this
+     */
+    public function removeType(string $type): Schema
+    {
+        unset($this->types[$type]);
+
+        return $this;
+    }
+
+    /**
      * @param string $name
      * @return Type|null
      */
@@ -703,12 +714,12 @@ class Schema implements ConfigurationApplier
 
         $union = $this->getUnion($typeName);
         if ($union instanceof ModelUnionType) {
-            return $this->getTypeOrModel($union->getInterface()->getModel()->getTypeName());
+            return $union->getCanonicalModel();
         }
 
         $interface = $this->getInterface($typeName);
         if ($interface instanceof ModelInterfaceType) {
-            return $this->getTypeOrModel($interface->getModel()->getTypeName());
+            return $interface;
         }
 
         return null;
@@ -761,6 +772,17 @@ class Schema implements ConfigurationApplier
     }
 
     /**
+     * @param string $name
+     * @return $this
+     */
+    public function removeEnum(string $name): self
+    {
+        unset($this->enums[$name]);
+
+        return $this;
+    }
+
+    /**
      * @return Enum[]
      */
     public function getEnums(): array
@@ -801,6 +823,17 @@ class Schema implements ConfigurationApplier
     public function addScalar(Scalar $scalar): self
     {
         $this->scalars[$scalar->getName()] = $scalar;
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @return $this
+     */
+    public function removeScalar(string $name): self
+    {
+        unset($this->scalars[$name]);
 
         return $this;
     }
@@ -862,6 +895,30 @@ class Schema implements ConfigurationApplier
             $callback($model);
         }
         return $this->addModel($model);
+    }
+
+    /**
+     * @param string $class
+     * @return $this
+     */
+    public function removeModelByClassName(string $class): self
+    {
+        if ($model = $this->getModelByClassName($class)) {
+            $this->removeModel($model->getName());
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @return $this
+     */
+    public function removeModel(string $name): self
+    {
+        unset($this->models[$name]);
+
+        return $this;
     }
 
     /**
@@ -940,6 +997,17 @@ class Schema implements ConfigurationApplier
 
     /**
      * @param string $name
+     * @return $this
+     */
+    public function removeInterface(string $name): self
+    {
+        unset($this->interfaces[$name]);
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
      * @return InterfaceType|null
      */
     public function getInterface(string $name): ?InterfaceType
@@ -968,6 +1036,17 @@ class Schema implements ConfigurationApplier
         if ($callback) {
             $callback($typeObj);
         }
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @return $this
+     */
+    public function removeUnion(string $name): self
+    {
+        unset($this->unions[$name]);
+
         return $this;
     }
 

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -950,6 +950,32 @@ class Schema implements ConfigurationApplier
     }
 
     /**
+     * Some types must be eagerly loaded into the schema if they cannot be discovered through introspection.
+     * This may include types that do not appear in any queries.
+     * @param string $name
+     * @return $this
+     * @throws SchemaBuilderException
+     */
+    public function eagerLoad(string $name): self
+    {
+        $this->getConfig()->set("eagerLoadTypes.$name", $name);
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @return $this
+     * @throws SchemaBuilderException
+     */
+    public function lazyLoad(string $name): self
+    {
+        $this->getConfig()->unset("eagerLoadTypes.$name");
+
+        return $this;
+    }
+
+    /**
      * @param string $class
      * @param array $config
      * @return ModelType|null
@@ -1034,6 +1060,14 @@ class Schema implements ConfigurationApplier
     public function getInterfaces(): array
     {
         return $this->interfaces;
+    }
+
+    public function getImplementorsOf(string $interfaceName): array
+    {
+        $search = array_merge($this->getTypes(), $this->getModels());
+        return array_filter($search, function (Type $type) use ($interfaceName) {
+            return $type->implements($interfaceName);
+        });
     }
 
     /**

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -454,8 +454,7 @@ class Schema implements ConfigurationApplier
     {
         $allTypeFields = [];
         $allModelFields = [];
-        $types = array_merge($this->types, $this->interfaces);
-        foreach ($types as $type) {
+        foreach ($this->types as $type) {
             if ($type->getIsInput()) {
                 continue;
             }
@@ -721,7 +720,7 @@ class Schema implements ConfigurationApplier
 
         $interface = $this->getInterface($typeName);
         if ($interface instanceof ModelInterfaceType) {
-            return $interface;
+            return $interface->getCanonicalModel();
         }
 
         return null;

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -24,7 +24,9 @@ use SilverStripe\GraphQL\Schema\Interfaces\TypePlugin;
 use SilverStripe\GraphQL\Schema\Type\Enum;
 use SilverStripe\GraphQL\Schema\Type\InputType;
 use SilverStripe\GraphQL\Schema\Type\InterfaceType;
+use SilverStripe\GraphQL\Schema\Type\ModelInterfaceType;
 use SilverStripe\GraphQL\Schema\Type\ModelType;
+use SilverStripe\GraphQL\Schema\Type\ModelUnionType;
 use SilverStripe\GraphQL\Schema\Type\Scalar;
 use SilverStripe\GraphQL\Schema\Type\Type;
 use SilverStripe\GraphQL\Schema\Type\TypeReference;
@@ -685,6 +687,33 @@ class Schema implements ConfigurationApplier
 
         return $this->getType($name);
     }
+
+    /**
+     * Given a type name, try to resolve it to any model-implementing component
+     *
+     * @param string $typeName
+     * @return Type|null
+     */
+    public function getCanonicalType(string $typeName): ?Type
+    {
+        $type = $this->getTypeOrModel($typeName);
+        if ($type) {
+            return $type;
+        }
+
+        $union = $this->getUnion($typeName);
+        if ($union instanceof ModelUnionType) {
+            return $this->getTypeOrModel($union->getInterface()->getModel()->getTypeName());
+        }
+
+        $interface = $this->getInterface($typeName);
+        if ($interface instanceof ModelInterfaceType) {
+            return $this->getTypeOrModel($interface->getModel()->getTypeName());
+        }
+
+        return null;
+    }
+
 
     /**
      * @return Type[]

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -108,6 +108,7 @@ class SchemaBuilder
      * @return GraphQLSchema
      * @throws SchemaBuilderException
      * @throws SchemaNotFoundException
+     * @throws EmptySchemaException
      */
     public function buildByName(string $key, $clear = false): GraphQLSchema
     {

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -136,7 +136,6 @@ class SchemaBuilder
     public function boot(string $key): Schema
     {
         $schemaObj = Schema::create($key);
-
         $schemas = $schemaObj->config()->get('schemas') ?: [];
 
         if (!array_key_exists($key, $schemas)) {

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -91,7 +91,7 @@ class SchemaBuilder
         $store->persistSchema($schema->createStoreableSchema());
 
         Dispatcher::singleton()->trigger(
-            'graphqlSchemaBuild.' . $schema->getSchemaKey(),
+            'graphqlSchemaBuild',
             Event::create($schema->getSchemaKey(), [
                 'schema' => $schema
             ])

--- a/src/Schema/SchemaConfig.php
+++ b/src/Schema/SchemaConfig.php
@@ -149,6 +149,16 @@ class SchemaConfig extends Configuration
         return $this->set('fieldMapping', $fields);
     }
 
+    /**
+     * @param string $class
+     * @return bool
+     * @throws SchemaBuilderException
+     */
+    public function hasModel(string $class): bool
+    {
+        return (bool) $this->get(['typeMapping', $class]);
+    }
+
 
     /**
      * @param string $class

--- a/src/Schema/Services/NestedInputBuilder.php
+++ b/src/Schema/Services/NestedInputBuilder.php
@@ -9,7 +9,9 @@ use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Field\Field;
 use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\GraphQL\Schema\Type\InputType;
+use SilverStripe\GraphQL\Schema\Type\ModelInterfaceType;
 use SilverStripe\GraphQL\Schema\Type\ModelType;
+use SilverStripe\GraphQL\Schema\Type\ModelUnionType;
 use SilverStripe\GraphQL\Schema\Type\Type;
 use SilverStripe\GraphQL\Schema\Type\TypeReference;
 use SilverStripe\ORM\ArrayLib;
@@ -93,7 +95,7 @@ class NestedInputBuilder
     public function populateSchema()
     {
         $typeName = TypeReference::create($this->root->getType())->getNamedType();
-        $type = $this->schema->getTypeOrModel($typeName);
+        $type = $this->schema->getCanonicalType($typeName);
         Schema::invariant(
             $type,
             'Could not find type for query that uses %s. Were plugins applied before the schema was done loading?',
@@ -341,6 +343,8 @@ class NestedInputBuilder
 
         return $fieldName;
     }
+
+
 
     /**
      * @param string $key

--- a/src/Schema/Storage/CodeGenerationStore.php
+++ b/src/Schema/Storage/CodeGenerationStore.php
@@ -4,7 +4,7 @@ namespace SilverStripe\GraphQL\Schema\Storage;
 
 use Exception;
 use GraphQL\Type\Schema as GraphQLSchema;
-use GraphQL\Type\SchemaConfig as GraphqLSchemaConfig;
+use GraphQL\Type\SchemaConfig as GraphQLSchemaConfig;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
@@ -290,6 +290,13 @@ class CodeGenerationStore implements SchemaStorageInterface
             $callback = call_user_func([$registryClass, Schema::MUTATION_TYPE]);
             $schemaConfig->setMutation($callback);
         }
+        // Add eager loaded types
+        $typeNames = $this->getConfig()->get('eagerLoadTypes', []);
+        $typeObjs = array_map(function (string $typeName) use ($registryClass) {
+            return call_user_func([$registryClass, $typeName]);
+        }, $typeNames);
+        $schemaConfig->setTypes($typeObjs);
+
         return new GraphQLSchema($schemaConfig);
     }
 

--- a/src/Schema/Storage/CodeGenerationStore.php
+++ b/src/Schema/Storage/CodeGenerationStore.php
@@ -299,10 +299,16 @@ class CodeGenerationStore implements SchemaStorageInterface
             $schemaConfig->setMutation($callback);
         }
         // Add eager loaded types
-        $typeNames = $this->getConfig()->get('eagerLoadTypes', []);
+        $typeNames = array_filter(
+            $this->getConfig()->get('eagerLoadTypes', []),
+            function (string $name) use ($registryClass) {
+                return method_exists($registryClass, $name);
+            }
+        );
         $typeObjs = array_map(function (string $typeName) use ($registryClass) {
             return call_user_func([$registryClass, $typeName]);
         }, $typeNames);
+
         $schemaConfig->setTypes($typeObjs);
 
         $this->graphqlSchema = new GraphQLSchema($schemaConfig);

--- a/src/Schema/Storage/templates/interface.inc.php
+++ b/src/Schema/Storage/templates/interface.inc.php
@@ -23,6 +23,13 @@ class <?=$interface->getName(); ?> extends InterfaceType
         <?php if (!empty($interface->getDescription())) : ?>
             'description' => '<?=addslashes($interface->getDescription()); ?>',
         <?php endif; ?>
+        <?php if (!empty($interface->getInterfaces())) : ?>
+            'interfaces' => function () {
+                return array_map(function ($interface) {
+                    return call_user_func([__NAMESPACE__ . '\\<?=$globals['typeClassName']; ?>', $interface]);
+                }, <?=$interface->getEncodedInterfaces(); ?>);
+            },
+        <?php endif; ?>
             'fields' => function () {
                 return [
                 <?php foreach ($interface->getFields() as $field) : ?>

--- a/src/Schema/Type/CanonicalModelAware.php
+++ b/src/Schema/Type/CanonicalModelAware.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Schema\Type;
+
+trait CanonicalModelAware
+{
+    /**
+     * @var ModelType
+     */
+    private $canonicalModel;
+
+    /**
+     * @return ModelType
+     */
+    public function getCanonicalModel(): ModelType
+    {
+        return $this->canonicalModel;
+    }
+
+    /**
+     * @param ModelType $modelType
+     * @return $this
+     */
+    public function setCanonicalModel(ModelType  $modelType): self
+    {
+        $this->canonicalModel = $modelType;
+
+        return $this;
+    }
+}

--- a/src/Schema/Type/ModelInterfaceType.php
+++ b/src/Schema/Type/ModelInterfaceType.php
@@ -12,18 +12,18 @@ use SilverStripe\GraphQL\Schema\Interfaces\SchemaModelInterface;
  */
 class ModelInterfaceType extends InterfaceType
 {
-    use ModelAware;
+    use CanonicalModelAware;
 
     /**
      * ModelInterfaceType constructor.
-     * @param SchemaModelInterface $model
+     * @param SchemaModelInterface $modelType
      * @param string $name
      * @param array|null $config
      * @throws SchemaBuilderException
      */
-    public function __construct(SchemaModelInterface $model, string $name, ?array $config = null)
+    public function __construct(ModelType $modelType, string $name, ?array $config = null)
     {
-        $this->setModel($model);
+        $this->setCanonicalModel($modelType);
         parent::__construct($name, $config);
     }
 }

--- a/src/Schema/Type/ModelInterfaceType.php
+++ b/src/Schema/Type/ModelInterfaceType.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Schema\Type;
 
-
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Field\ModelAware;
 use SilverStripe\GraphQL\Schema\Interfaces\SchemaModelInterface;

--- a/src/Schema/Type/ModelInterfaceType.php
+++ b/src/Schema/Type/ModelInterfaceType.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Schema\Type;
+
+
+use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
+use SilverStripe\GraphQL\Schema\Field\ModelAware;
+use SilverStripe\GraphQL\Schema\Interfaces\SchemaModelInterface;
+
+/**
+ * Defines an interface that is backed by a model
+ */
+class ModelInterfaceType extends InterfaceType
+{
+    use ModelAware;
+
+    /**
+     * ModelInterfaceType constructor.
+     * @param SchemaModelInterface $model
+     * @param string $name
+     * @param array|null $config
+     * @throws SchemaBuilderException
+     */
+    public function __construct(SchemaModelInterface $model, string $name, ?array $config = null)
+    {
+        $this->setModel($model);
+        parent::__construct($name, $config);
+    }
+}

--- a/src/Schema/Type/ModelType.php
+++ b/src/Schema/Type/ModelType.php
@@ -204,7 +204,7 @@ class ModelType extends Type implements ExtraTypeProvider
         }
         $allFields = $this->getModel()->getAllFields();
         foreach ($allFields as $fieldName) {
-            if(!$this->getFieldByName($fieldName)) {
+            if (!$this->getFieldByName($fieldName)) {
                 $this->addField($fieldName, $this->getModel()->getField($fieldName));
             }
         }

--- a/src/Schema/Type/ModelType.php
+++ b/src/Schema/Type/ModelType.php
@@ -142,6 +142,13 @@ class ModelType extends Type implements ExtraTypeProvider
                 }
             } else {
                 $fieldObj = ModelField::create($fieldName, $fieldConfig, $this->getModel());
+                Schema::invariant(
+                    $fieldObj->getType(),
+                    'Field %s on type %s could not infer a type. Check to see if the field exists on the model
+                    or provide an explicit type if necessary.',
+                    $fieldObj->getName(),
+                    $this->getName()
+                );
             }
         }
         Schema::invariant(

--- a/src/Schema/Type/ModelType.php
+++ b/src/Schema/Type/ModelType.php
@@ -7,6 +7,7 @@ use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Field\Field;
 use SilverStripe\GraphQL\Schema\Field\ModelAware;
 use SilverStripe\GraphQL\Schema\Field\ModelField;
+use SilverStripe\GraphQL\Schema\Interfaces\BaseFieldsProvider;
 use SilverStripe\GraphQL\Schema\Interfaces\DefaultFieldsProvider;
 use SilverStripe\GraphQL\Schema\Interfaces\ExtraTypeProvider;
 use SilverStripe\GraphQL\Schema\Interfaces\InputTypeProvider;
@@ -55,7 +56,6 @@ class ModelType extends Type implements ExtraTypeProvider
     {
         $this->setModel($model);
         $type = $this->getModel()->getTypeName();
-
         Schema::invariant(
             $type,
             'Could not determine type for model %s',
@@ -84,7 +84,7 @@ class ModelType extends Type implements ExtraTypeProvider
         if ($fieldConfig === Schema::ALL) {
             $this->addAllFields();
         } else {
-            $fields = array_merge($this->getBaseFields(), $fieldConfig);
+            $fields = array_merge($this->getInitialFields(), $fieldConfig);
             Schema::assertValidConfig($fields);
 
             foreach ($fields as $fieldName => $data) {
@@ -191,15 +191,15 @@ class ModelType extends Type implements ExtraTypeProvider
      */
     public function addAllFields(): self
     {
-        /* @var SchemaModelInterface&DefaultFieldsProvider $model */
-        $model = $this->getModel();
-        $defaultFields = $model instanceof DefaultFieldsProvider ? $model->getDefaultFields() : [];
-        foreach ($defaultFields as $fieldName => $fieldType) {
+        $initialFields = $this->getInitialFields();
+        foreach ($initialFields as $fieldName => $fieldType) {
             $this->addField($fieldName, $fieldType);
         }
         $allFields = $this->getModel()->getAllFields();
         foreach ($allFields as $fieldName) {
-            $this->addField($fieldName, $this->getModel()->getField($fieldName));
+            if(!$this->getFieldByName($fieldName)) {
+                $this->addField($fieldName, $this->getModel()->getField($fieldName));
+            }
         }
         return $this;
     }
@@ -422,13 +422,34 @@ class ModelType extends Type implements ExtraTypeProvider
     }
 
     /**
+     * @throws SchemaBuilderException
+     */
+    public function validate(): void
+    {
+        if ($this->getModel() instanceof BaseFieldsProvider) {
+            foreach ($this->getModel()->getBaseFields() as $fieldName => $data) {
+                Schema::invariant(
+                    $this->getFieldByName($fieldName),
+                    'Required base field %s was not on type %s',
+                    $fieldName,
+                    $this->getName()
+                );
+            }
+        }
+        parent::validate();
+    }
+
+    /**
      * @return array
      */
-    private function getBaseFields(): array
+    private function getInitialFields(): array
     {
         $model = $this->getModel();
         /* @var SchemaModelInterface&DefaultFieldsProvider $model */
-        return $model instanceof DefaultFieldsProvider ? $model->getDefaultFields() : [];
+        $default = $model instanceof DefaultFieldsProvider ? $model->getDefaultFields() : [];
+        $base = $model instanceof BaseFieldsProvider ? $model->getBaseFields() : [];
+
+        return array_merge($default, $base);
     }
 
     /**

--- a/src/Schema/Type/ModelUnionType.php
+++ b/src/Schema/Type/ModelUnionType.php
@@ -1,0 +1,52 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Schema\Type;
+
+use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
+
+/**
+ * Defines a union that is backed by a model definition
+ */
+class ModelUnionType extends UnionType
+{
+    /**
+     * @var ModelInterfaceType
+     */
+    private $interface;
+
+    /**
+     * ModelUnionType constructor.
+     * @param ModelInterfaceType $interface
+     * @param string $name
+     * @param array|null $config
+     * @throws SchemaBuilderException
+     */
+    public function __construct(ModelInterfaceType $interface, string $name, ?array $config = null)
+    {
+        $this->setInterface($interface);
+        parent::__construct($name, $config);
+    }
+
+    /**
+     * @return ModelInterfaceType
+     */
+    public function getInterface(): ModelInterfaceType
+    {
+        return $this->interface;
+    }
+
+    /**
+     * @param ModelInterfaceType $interface
+     * @return $this
+     */
+    public function setInterface(ModelInterfaceType  $interface): self
+    {
+        $this->interface = $interface;
+
+        return $this;
+    }
+
+
+
+}

--- a/src/Schema/Type/ModelUnionType.php
+++ b/src/Schema/Type/ModelUnionType.php
@@ -11,42 +11,39 @@ use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 class ModelUnionType extends UnionType
 {
     /**
-     * @var ModelInterfaceType
+     * @var ModelType
      */
-    private $interface;
+    private $canonicalModel;
 
     /**
      * ModelUnionType constructor.
-     * @param ModelInterfaceType $interface
+     * @param ModelType $canonicalModel
      * @param string $name
      * @param array|null $config
      * @throws SchemaBuilderException
      */
-    public function __construct(ModelInterfaceType $interface, string $name, ?array $config = null)
+    public function __construct(ModelType $canonicalModel, string $name, ?array $config = null)
     {
-        $this->setInterface($interface);
+        $this->setCanonicalModel($canonicalModel);
         parent::__construct($name, $config);
     }
 
     /**
-     * @return ModelInterfaceType
+     * @return ModelType
      */
-    public function getInterface(): ModelInterfaceType
+    public function getCanonicalModel(): ModelType
     {
-        return $this->interface;
+        return $this->canonicalModel;
     }
 
     /**
-     * @param ModelInterfaceType $interface
+     * @param ModelType $modelType
      * @return $this
      */
-    public function setInterface(ModelInterfaceType  $interface): self
+    public function setCanonicalModel(ModelType  $modelType): self
     {
-        $this->interface = $interface;
+        $this->canonicalModel = $modelType;
 
         return $this;
     }
-
-
-
 }

--- a/src/Schema/Type/ModelUnionType.php
+++ b/src/Schema/Type/ModelUnionType.php
@@ -10,10 +10,7 @@ use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
  */
 class ModelUnionType extends UnionType
 {
-    /**
-     * @var ModelType
-     */
-    private $canonicalModel;
+    use CanonicalModelAware;
 
     /**
      * ModelUnionType constructor.
@@ -26,24 +23,5 @@ class ModelUnionType extends UnionType
     {
         $this->setCanonicalModel($canonicalModel);
         parent::__construct($name, $config);
-    }
-
-    /**
-     * @return ModelType
-     */
-    public function getCanonicalModel(): ModelType
-    {
-        return $this->canonicalModel;
-    }
-
-    /**
-     * @param ModelType $modelType
-     * @return $this
-     */
-    public function setCanonicalModel(ModelType  $modelType): self
-    {
-        $this->canonicalModel = $modelType;
-
-        return $this;
     }
 }

--- a/src/Schema/Type/Type.php
+++ b/src/Schema/Type/Type.php
@@ -307,6 +307,15 @@ class Type implements ConfigurationApplier, SchemaValidator, SignatureProvider, 
     }
 
     /**
+     * @param string $interfaceName
+     * @return bool
+     */
+    public function implements(string $interfaceName): bool
+    {
+        return in_array($interfaceName, $this->interfaces);
+    }
+
+    /**
      * @return bool
      */
     public function getIsInput(): bool

--- a/src/Schema/Type/Type.php
+++ b/src/Schema/Type/Type.php
@@ -222,7 +222,14 @@ class Type implements ConfigurationApplier, SchemaValidator, SignatureProvider, 
 
         $this->mergePlugins($type->getPlugins());
 
-        $this->setInterfaces(array_merge($this->interfaces, $type->getInterfaces()));
+        $this->setInterfaces(
+            array_unique(
+                array_merge(
+                    $this->interfaces,
+                    $type->getInterfaces()
+                )
+            )
+        );
 
         return $this;
     }

--- a/src/Schema/Type/UnionType.php
+++ b/src/Schema/Type/UnionType.php
@@ -176,6 +176,26 @@ class UnionType implements
     }
 
     /**
+     * @param UnionType $existing
+     * @throws SchemaBuilderException
+     */
+    public function mergeWith(UnionType $existing)
+    {
+        $this->setName($existing->getName());
+        $this->setTypes(array_unique(
+            array_merge(
+                $this->getTypes(),
+                $existing->getTypes()
+            )
+        ));
+        if ($existing->getTypeResolver()) {
+            $this->setTypeResolver($existing->getTypeResolver());
+        }
+
+        return $this;
+    }
+
+    /**
      * @throws SchemaBuilderException
      */
     public function validate(): void

--- a/tests/Fake/Inheritance/A.php
+++ b/tests/Fake/Inheritance/A.php
@@ -5,6 +5,7 @@ namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
 
 
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 
 class A extends DataObject implements TestOnly
@@ -14,4 +15,9 @@ class A extends DataObject implements TestOnly
     ];
 
     private static $table_name = 'A_test';
+
+    public function getAllTheB(): DataList
+    {
+        return B::get();
+    }
 }

--- a/tests/Fake/Inheritance/A.php
+++ b/tests/Fake/Inheritance/A.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
 
-
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;

--- a/tests/Fake/Inheritance/A.php
+++ b/tests/Fake/Inheritance/A.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class A extends DataObject implements TestOnly
+{
+    private static $db = [
+        'AField' => 'Varchar',
+    ];
+
+    private static $table_name = 'A_test';
+}

--- a/tests/Fake/Inheritance/A1.php
+++ b/tests/Fake/Inheritance/A1.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class A1 extends A
+{
+    private static $db = [
+        'A1Field' => 'Varchar',
+    ];
+
+    private static $table_name = 'A1_test';
+}

--- a/tests/Fake/Inheritance/A1a.php
+++ b/tests/Fake/Inheritance/A1a.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class A1a extends A1
+{
+    private static $db = [
+        'A1aField' => 'Varchar',
+    ];
+
+    private static $table_name = 'A1a_test';
+}

--- a/tests/Fake/Inheritance/A1b.php
+++ b/tests/Fake/Inheritance/A1b.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class A1b extends A1
+{
+    private static $db = [
+        'A1bField' => 'Varchar',
+    ];
+
+    private static $table_name = 'A1b_test';
+}

--- a/tests/Fake/Inheritance/A2.php
+++ b/tests/Fake/Inheritance/A2.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class A2 extends A
+{
+    private static $db = [
+        'A2Field' => 'Varchar',
+    ];
+
+    private static $table_name = 'A2_test';
+}

--- a/tests/Fake/Inheritance/A2a.php
+++ b/tests/Fake/Inheritance/A2a.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class A2a extends A2
+{
+    private static $db = [
+        'A2aField' => 'Varchar',
+    ];
+
+    private static $table_name = 'A2a_test';
+}

--- a/tests/Fake/Inheritance/B.php
+++ b/tests/Fake/Inheritance/B.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class B extends DataObject implements TestOnly
+{
+    private static $db = [
+        'BField' => 'Varchar',
+    ];
+
+    private static $table_name = 'B_test';
+}

--- a/tests/Fake/Inheritance/B1.php
+++ b/tests/Fake/Inheritance/B1.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class B1 extends B
+{
+    private static $db = [
+    ];
+
+    private static $table_name = 'B1_test';
+}

--- a/tests/Fake/Inheritance/B1a.php
+++ b/tests/Fake/Inheritance/B1a.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class B1a extends B1
+{
+    private static $db = [
+        'B1aField' => 'Varchar',
+    ];
+
+    private static $table_name = 'B1a_test';
+}

--- a/tests/Fake/Inheritance/B1b.php
+++ b/tests/Fake/Inheritance/B1b.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class B1b extends B1
+{
+    private static $db = [
+        'B1bField' => 'Varchar',
+    ];
+
+    private static $table_name = 'B1b_test';
+}

--- a/tests/Fake/Inheritance/B2.php
+++ b/tests/Fake/Inheritance/B2.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class B2 extends B
+{
+    private static $db = [
+        'B2Field' => 'Varchar',
+    ];
+
+    private static $table_name = 'B2_test';
+}

--- a/tests/Fake/Inheritance/C.php
+++ b/tests/Fake/Inheritance/C.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class C extends DataObject implements TestOnly
+{
+    private static $db = [
+        'CField' => 'Varchar',
+    ];
+
+    private static $table_name = 'C_test';
+}

--- a/tests/Fake/Inheritance/C1.php
+++ b/tests/Fake/Inheritance/C1.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class C1 extends C
+{
+    private static $db = [
+        'C1Field' => 'Varchar',
+    ];
+
+    private static $table_name = 'C1_test';
+}

--- a/tests/Fake/Inheritance/C2.php
+++ b/tests/Fake/Inheritance/C2.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class C2 extends C
+{
+    private static $db = [
+        'C2Field' => 'Varchar',
+    ];
+
+    private static $table_name = 'C2_test';
+}

--- a/tests/Fake/Inheritance/C2a.php
+++ b/tests/Fake/Inheritance/C2a.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+class C2a extends C2
+{
+    private static $db = [
+        'C2aField' => 'Varchar',
+    ];
+
+    private static $table_name = 'C2a_test';
+}

--- a/tests/Schema/DataObject/FakeInheritanceBuilder.php
+++ b/tests/Schema/DataObject/FakeInheritanceBuilder.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
 
-
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\GraphQL\Schema\DataObject\InheritanceBuilder;
 use SilverStripe\GraphQL\Schema\Type\ModelType;
@@ -15,7 +14,7 @@ class FakeInheritanceBuilder extends InheritanceBuilder implements TestOnly
 
     public function fillAncestry(ModelType $modelType): void
     {
-       static::$ancestryCalls[$modelType->getName()] = true;
+        static::$ancestryCalls[$modelType->getName()] = true;
     }
 
     public function fillDescendants(ModelType $modelType): void

--- a/tests/Schema/DataObject/FakeInheritanceBuilder.php
+++ b/tests/Schema/DataObject/FakeInheritanceBuilder.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
+
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\GraphQL\Schema\DataObject\InheritanceBuilder;
+use SilverStripe\GraphQL\Schema\Type\ModelType;
+
+class FakeInheritanceBuilder extends InheritanceBuilder implements TestOnly
+{
+    public static $ancestryCalls = [];
+    public static $descendantCalls = [];
+
+    public function fillAncestry(ModelType $modelType): void
+    {
+       static::$ancestryCalls[$modelType->getName()] = true;
+    }
+
+    public function fillDescendants(ModelType $modelType): void
+    {
+        static::$descendantCalls[$modelType->getName()] = true;
+    }
+}

--- a/tests/Schema/DataObject/FakeInheritanceUnionBuilder.php
+++ b/tests/Schema/DataObject/FakeInheritanceUnionBuilder.php
@@ -1,0 +1,24 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
+
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\GraphQL\Schema\DataObject\InheritanceUnionBuilder;
+
+class FakeInheritanceUnionBuilder extends InheritanceUnionBuilder implements TestOnly
+{
+    public static $createCalled = false;
+    public static $applyCalled = false;
+
+    public function createUnions(): void
+    {
+        static::$createCalled = true;
+    }
+
+    public function applyUnions(): void
+    {
+        static::$applyCalled = true;
+    }
+}

--- a/tests/Schema/DataObject/FakeInheritanceUnionBuilder.php
+++ b/tests/Schema/DataObject/FakeInheritanceUnionBuilder.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
 
-
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\GraphQL\Schema\DataObject\InheritanceUnionBuilder;
 

--- a/tests/Schema/DataObject/FakeInheritanceUnionBuilder.php
+++ b/tests/Schema/DataObject/FakeInheritanceUnionBuilder.php
@@ -11,13 +11,21 @@ class FakeInheritanceUnionBuilder extends InheritanceUnionBuilder implements Tes
     public static $createCalled = false;
     public static $applyCalled = false;
 
-    public function createUnions(): void
+    public static function reset()
     {
-        static::$createCalled = true;
+        self::$createCalled = false;
+        self::$applyCalled = false;
     }
 
-    public function applyUnions(): void
+    public function createUnions(): self
+    {
+        static::$createCalled = true;
+        return $this;
+    }
+
+    public function applyUnionsToQueries(): self
     {
         static::$applyCalled = true;
+        return $this;
     }
 }

--- a/tests/Schema/DataObject/FakeInterfaceBuilder.php
+++ b/tests/Schema/DataObject/FakeInterfaceBuilder.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
+
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\GraphQL\Schema\DataObject\InterfaceBuilder;
+use SilverStripe\GraphQL\Schema\Type\ModelType;
+
+class FakeInterfaceBuilder extends InterfaceBuilder implements TestOnly
+{
+    public static $createCalls = [];
+    public static $baseCalled = false;
+
+    public function createInterfaces(ModelType $modelType, array $interfaceStack = []): void
+    {
+        static::$createCalls[$modelType->getName()] = true;
+    }
+
+    public function applyBaseInterface(): void
+    {
+        static::$baseCalled = true;
+    }
+
+}

--- a/tests/Schema/DataObject/FakeInterfaceBuilder.php
+++ b/tests/Schema/DataObject/FakeInterfaceBuilder.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
 
-
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\GraphQL\Schema\DataObject\InterfaceBuilder;
 use SilverStripe\GraphQL\Schema\Type\ModelType;
@@ -22,5 +21,4 @@ class FakeInterfaceBuilder extends InterfaceBuilder implements TestOnly
     {
         static::$baseCalled = true;
     }
-
 }

--- a/tests/Schema/DataObject/FakeInterfaceBuilder.php
+++ b/tests/Schema/DataObject/FakeInterfaceBuilder.php
@@ -11,14 +11,30 @@ class FakeInterfaceBuilder extends InterfaceBuilder implements TestOnly
 {
     public static $createCalls = [];
     public static $baseCalled = false;
+    public static $applyCalled = false;
 
-    public function createInterfaces(ModelType $modelType, array $interfaceStack = []): void
+    public static function reset()
     {
-        static::$createCalls[$modelType->getName()] = true;
+        self::$createCalls = [];
+        self::$baseCalled = false;
+        self::$applyCalled = false;
     }
 
-    public function applyBaseInterface(): void
+    public function createInterfaces(ModelType $modelType, array $interfaceStack = []): self
+    {
+        static::$createCalls[$modelType->getName()] = true;
+        return $this;
+    }
+
+    public function applyBaseInterface(): self
     {
         static::$baseCalled = true;
+        return $this;
+    }
+
+    public function applyInterfacesToQueries(): InterfaceBuilder
+    {
+        self::$applyCalled = true;
+        return $this;
     }
 }

--- a/tests/Schema/DataObject/InheritanceBuilderTest.php
+++ b/tests/Schema/DataObject/InheritanceBuilderTest.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
 
-
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Schema\DataObject\InheritanceBuilder;
 use SilverStripe\GraphQL\Schema\Type\Type;
@@ -108,7 +107,6 @@ class InheritanceBuilderTest extends SapphireTest
         $this->assertTrue($builder->isBaseModel(A::class));
         $this->assertFalse($builder->isBaseModel(A1::class));
         $this->assertFalse($builder->isBaseModel(Aa::class));
-
     }
 
     public function testLeafModel()
@@ -176,7 +174,6 @@ class InheritanceBuilderTest extends SapphireTest
         $this->assertTrue($builder->isLeafModel(A1a::class));
         $this->assertFalse($builder->isLeafModel(A1::class));
         $this->assertFalse($builder->isLeafModel(A::class));
-
     }
 
     public function testFillAncestry()
@@ -210,7 +207,6 @@ class InheritanceBuilderTest extends SapphireTest
         $a = $schema->getModelByClassName(A::class);
         $this->assertNotNull($a);
         $this->assertFields(['AField', 'id'], $a);
-
     }
 
     public function testFillDescendants()
@@ -318,5 +314,4 @@ class InheritanceBuilderTest extends SapphireTest
         $this->assertEmpty(array_diff($expected, $compare));
         $this->assertEmpty(array_diff($compare, $expected));
     }
-
 }

--- a/tests/Schema/DataObject/InheritanceBuilderTest.php
+++ b/tests/Schema/DataObject/InheritanceBuilderTest.php
@@ -1,0 +1,322 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
+
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Schema\DataObject\InheritanceBuilder;
+use SilverStripe\GraphQL\Schema\Type\Type;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1a;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1b;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A2;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A2a;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B1;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B1a;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B1b;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B2;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\C;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\C1;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\C2;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\C2a;
+
+class InheritanceBuilderTest extends SapphireTest
+{
+    protected static $extra_dataobjects = [
+        A::class,
+        A1::class,
+        A1a::class,
+        A1b::class,
+        A2::class,
+        A2a::class,
+        B::class,
+        B1::class,
+        B1a::class,
+        B1b::class,
+        B2::class,
+        C::class,
+        C1::class,
+        C2::class,
+        C2a::class,
+    ];
+
+    public function testBaseModel()
+    {
+        $schema = new TestSchema();
+
+        $schema->applyConfig([
+            'models' => [
+                A1a::class => [
+                    'fields' => [
+                        'A1aField' => true,
+                        'AField' => true,
+                    ],
+                ],
+            ],
+        ]);
+        $schema->createStoreableSchema();
+
+        $builder = new InheritanceBuilder($schema);
+        $this->assertTrue($builder->isBaseModel(A1a::class));
+        $this->assertFalse($builder->isBaseModel(A1::class));
+        $this->assertFalse($builder->isBaseModel(A::class));
+
+        $schema->applyConfig([
+            'models' => [
+                A1::class => [
+                    'fields' => [
+                        'A1Field' => true,
+                    ],
+                ],
+                A1a::class => [
+                    'fields' => [
+                        'A1aField' => true,
+                        'AField' => true,
+                    ],
+                ],
+            ],
+        ]);
+        $schema->createStoreableSchema();
+        $this->assertTrue($builder->isBaseModel(A1::class));
+        $this->assertFalse($builder->isBaseModel(A1a::class));
+        $this->assertFalse($builder->isBaseModel(A::class));
+
+        $schema->applyConfig([
+            'models' => [
+                A::class => [
+                    'fields' => [
+                        'AField' => true,
+                    ],
+                ],
+                A1::class => [
+                    'fields' => [
+                        'A1Field' => true,
+                    ],
+                ],
+                A1a::class => [
+                    'fields' => [
+                        'A1aField' => true,
+                        'AField' => true,
+                    ],
+                ],
+            ],
+        ]);
+        $schema->createStoreableSchema();
+        $this->assertTrue($builder->isBaseModel(A::class));
+        $this->assertFalse($builder->isBaseModel(A1::class));
+        $this->assertFalse($builder->isBaseModel(Aa::class));
+
+    }
+
+    public function testLeafModel()
+    {
+        $schema = new TestSchema();
+
+        $schema->applyConfig([
+            'models' => [
+                A1a::class => [
+                    'fields' => [
+                        'A1aField' => true,
+                        'AField' => true,
+                    ],
+                ],
+            ],
+        ]);
+        $schema->createStoreableSchema();
+
+        $builder = new InheritanceBuilder($schema);
+        $this->assertTrue($builder->isLeafModel(A1a::class));
+        $this->assertFalse($builder->isLeafModel(A1::class));
+        $this->assertFalse($builder->isLeafModel(A::class));
+
+        $schema->applyConfig([
+            'models' => [
+                A1::class => [
+                    'fields' => [
+                        'A1Field' => true,
+                    ],
+                ],
+                A1a::class => [
+                    'fields' => [
+                        'A1aField' => true,
+                        'AField' => true,
+                    ],
+                ],
+            ],
+        ]);
+        $schema->createStoreableSchema();
+        $this->assertTrue($builder->isLeafModel(A1a::class));
+        $this->assertFalse($builder->isLeafModel(A1::class));
+        $this->assertFalse($builder->isLeafModel(A::class));
+
+        $schema->applyConfig([
+            'models' => [
+                A::class => [
+                    'fields' => [
+                        'AField' => true,
+                    ],
+                ],
+                A1::class => [
+                    'fields' => [
+                        'A1Field' => true,
+                    ],
+                ],
+                A1a::class => [
+                    'fields' => [
+                        'A1aField' => true,
+                        'AField' => true,
+                    ],
+                ],
+            ],
+        ]);
+        $schema->createStoreableSchema();
+        $this->assertTrue($builder->isLeafModel(A1a::class));
+        $this->assertFalse($builder->isLeafModel(A1::class));
+        $this->assertFalse($builder->isLeafModel(A::class));
+
+    }
+
+    public function testFillAncestry()
+    {
+        $schema = new TestSchema();
+
+        $schema->applyConfig([
+            'models' => [
+                A1a::class => [
+                    'fields' => [
+                        'A1aField' => true,
+                        'AField' => true,
+                    ],
+                    'operations' => ['read' => true],
+                ],
+            ],
+        ]);
+        $schema->createStoreableSchema();
+
+        $builder = new InheritanceBuilder($schema);
+        $builder->fillAncestry($schema->getModelByClassName(A1a::class));
+
+        $a1a = $schema->getModelByClassName(A1a::class);
+        $this->assertNotNull($a1a);
+        $this->assertFields(['A1aField', 'AField', 'id'], $a1a);
+
+        $a1 = $schema->getModelByClassName(A1::class);
+        $this->assertNotNull($a1);
+        $this->assertFields(['AField', 'id'], $a1);
+
+        $a = $schema->getModelByClassName(A::class);
+        $this->assertNotNull($a);
+        $this->assertFields(['AField', 'id'], $a);
+
+    }
+
+    public function testFillDescendants()
+    {
+        $schema = new TestSchema();
+        $schema->applyConfig([
+            'models' => [
+                A::class => [
+                    'fields' => [
+                        'AField' => true,
+                    ],
+                ],
+                A1::class => [
+                    'fields' => [
+                        'A1Field' => true,
+                    ],
+                ],
+                B::class => [
+                    'fields' => [
+                        'BField' => true,
+                    ],
+                ],
+                B1a::class => [
+                    'fields' => [
+                        'B1aField' => true,
+                    ],
+                ],
+                C::class => [
+                    'fields' => [
+                        'CField' => true,
+                    ],
+                ],
+                C2a::class => [
+                    'fields' => [
+                        'C2aField' => true,
+                        'C2Field' => true,
+                    ],
+                ],
+
+            ],
+        ]);
+        $schema->createStoreableSchema();
+
+        $builder = new InheritanceBuilder($schema);
+        $builder->fillDescendants($schema->getModelByClassName(A::class));
+
+        $a = $schema->getModelByClassName(A::class);
+        $this->assertNotNull($a);
+        $this->assertFields(['AField', 'id'], $a);
+        $a1 = $schema->getModelByClassName(A1::class);
+        $this->assertNotNull($a1);
+        $this->assertFields(['A1Field', 'AField', 'id'], $a1);
+
+        // This descendant wasn't explicitly exposed.
+        $a1a = $schema->getModelByClassName(A1a::class);
+        $this->assertNull($a1a);
+
+
+        // B
+        $builder->fillDescendants($schema->getModelByClassName(B::class));
+
+        $b = $schema->getModelByClassName(B::class);
+        $this->assertNotNull($b);
+        $this->assertFields(['BField', 'id'], $b);
+
+        // This descendant wasn't explicitly exposed.
+        $b1 = $schema->getModelByClassName(B1::class);
+        $this->assertNull($b1);
+
+        // But this one was. In practice, B1 would be exposed by fillAncestry()
+        $b1a = $schema->getModelByClassName(B1a::class);
+        $this->assertNotNull($b1a);
+        // Only has its native fields. fillAncestry() would take care of the others in practice.
+        $this->assertFields(['B1aField', 'id'], $b1a);
+
+        // C
+        $builder->fillDescendants($schema->getModelByClassName(C::class));
+
+        $c = $schema->getModelByClassName(C::class);
+        $this->assertNotNull($c);
+        $this->assertFields(['CField', 'id'], $c);
+
+        // Not explicitly exposed
+        $this->assertNull($schema->getModelByClassName(C1::class));
+
+        // Not explicitly exposed, but would be in practice by fillAncestry(), due to C2a
+        $c2 = $schema->getModelByClassName(C2::class);
+        $this->assertNull($c2);
+
+        $c2a = $schema->getModelByClassName(C2a::class);
+        $this->assertNotNull($c2a);
+        // Only has what was explicitly added. fillAncestry() would take care of the others in practice.
+        $this->assertFields(['C2aField', 'C2Field', 'id'], $c2a);
+    }
+
+    /**
+     * @param array $fields
+     * @param Type $type
+     */
+    private function assertFields(array $fields, Type $type)
+    {
+        $expected = array_map('strtolower', $fields);
+        $compare = array_map('strtolower', array_keys($type->getFields()));
+
+        $this->assertEmpty(array_diff($expected, $compare));
+        $this->assertEmpty(array_diff($compare, $expected));
+    }
+
+}

--- a/tests/Schema/DataObject/InheritanceUnionBuilderTest.php
+++ b/tests/Schema/DataObject/InheritanceUnionBuilderTest.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
 
-
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Schema\DataObject\InheritanceUnionBuilder;
 use SilverStripe\GraphQL\Schema\Type\ModelInterfaceType;
@@ -49,19 +48,17 @@ class InheritanceUnionBuilderTest extends SapphireTest
 
         $union = $schema->getUnion('A1InheritanceUnion');
         $this->assertNotNull($union);
-        $this->assertTypes(['A', 'A1', 'A1a', 'A1b'], $union);
+        $this->assertTypes(['A1', 'A1a', 'A1b'], $union);
 
         $union = $schema->getUnion('A2InheritanceUnion');
         $this->assertNotNull($union);
-        $this->assertTypes(['A', 'A2', 'A2a'], $union);
+        $this->assertTypes(['A2', 'A2a'], $union);
 
         $union = $schema->getUnion('A1aInheritanceUnion');
-        $this->assertNotNull($union);
-        $this->assertTypes(['A', 'A1', 'A1a'], $union);
+        $this->assertNull($union);
 
         $union = $schema->getUnion('A2aInheritanceUnion');
-        $this->assertNotNull($union);
-        $this->assertTypes(['A', 'A2', 'A2a'], $union);
+        $this->assertNull($union);
 
         $schema = new TestSchema();
         foreach (static::$extra_dataobjects as $class) {
@@ -74,7 +71,8 @@ class InheritanceUnionBuilderTest extends SapphireTest
         $schema->removeModelByClassName(A1::class);
         $schema->createStoreableSchema();
         $builder = new InheritanceUnionBuilder($schema);
-        $builder->createUnions();;
+        $builder->createUnions();
+        ;
         $union = $schema->getUnion('AInheritanceUnion');
         $this->assertNotNull($union);
         $this->assertTypes(['A', 'A2', 'A2a', 'A1a', 'A1b'], $union);
@@ -83,14 +81,11 @@ class InheritanceUnionBuilderTest extends SapphireTest
         $this->assertNull($union);
 
         $union = $schema->getUnion('A1aInheritanceUnion');
-        $this->assertNotNull($union);
-        $this->assertTypes(['A', 'A1a'], $union);
+        $this->assertNull($union);
 
         // Sanity check
         $union = $schema->getUnion('A2aInheritanceUnion');
-        $this->assertNotNull($union);
-        $this->assertTypes(['A', 'A2', 'A2a'], $union);
-
+        $this->assertNull($union);
     }
 
     public function testApplyUnions()
@@ -131,7 +126,6 @@ class InheritanceUnionBuilderTest extends SapphireTest
 
         $interface = $schema->getInterface('AInterface');
         $this->assertEquals('BInheritanceUnion', $interface->getFieldByName('allTheB')->getNamedType());
-
     }
 
     public function testUnionName()
@@ -161,5 +155,4 @@ class InheritanceUnionBuilderTest extends SapphireTest
         $this->assertEmpty(array_diff($expected, $compare));
         $this->assertEmpty(array_diff($compare, $expected));
     }
-
 }

--- a/tests/Schema/DataObject/InheritanceUnionBuilderTest.php
+++ b/tests/Schema/DataObject/InheritanceUnionBuilderTest.php
@@ -99,7 +99,7 @@ class InheritanceUnionBuilderTest extends SapphireTest
         }
         $schema->getModelByClassName(A::class)->addField('allTheB', '[B]');
         $a = $schema->getModel('A');
-        $interface = new ModelInterfaceType($a->getModel(), 'AInterface');
+        $interface = new ModelInterfaceType($a, 'AInterface');
         $modelQuery = clone $a->getFieldByName('allTheB');
         $interface->addField('allTheB', $modelQuery);
         $schema->addInterface($interface);
@@ -108,7 +108,7 @@ class InheritanceUnionBuilderTest extends SapphireTest
         $schema->createStoreableSchema();
         $builder = new InheritanceUnionBuilder($schema);
         $builder->createUnions();
-        $builder->applyUnions();
+        $builder->applyUnionsToQueries();
 
         $query = $schema->getQueryType()->getFieldByName('readAs');
         $this->assertNotNull($query);

--- a/tests/Schema/DataObject/InheritanceUnionBuilderTest.php
+++ b/tests/Schema/DataObject/InheritanceUnionBuilderTest.php
@@ -1,0 +1,165 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
+
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Schema\DataObject\InheritanceUnionBuilder;
+use SilverStripe\GraphQL\Schema\Type\ModelInterfaceType;
+use SilverStripe\GraphQL\Schema\Type\ModelType;
+use SilverStripe\GraphQL\Schema\Type\UnionType;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1a;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1b;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A2;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A2a;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B1;
+
+class InheritanceUnionBuilderTest extends SapphireTest
+{
+    protected static $extra_dataobjects = [
+        A::class,
+        A1::class,
+        A1a::class,
+        A1b::class,
+        A2::class,
+        A2a::class,
+        B::class,
+        B1::class,
+    ];
+
+    public function testCreateUnions()
+    {
+        $schema = new TestSchema();
+        foreach (static::$extra_dataobjects as $class) {
+            $schema->addModelbyClassName($class, function (ModelType $model) {
+                $model->addAllFields();
+            });
+        }
+        $schema->createStoreableSchema();
+        $builder = new InheritanceUnionBuilder($schema);
+        $builder->createUnions();
+
+        $union = $schema->getUnion('AInheritanceUnion');
+        $this->assertNotNull($union);
+        $this->assertTypes(['A', 'A1', 'A2', 'A2a', 'A1a', 'A1b'], $union);
+
+        $union = $schema->getUnion('A1InheritanceUnion');
+        $this->assertNotNull($union);
+        $this->assertTypes(['A', 'A1', 'A1a', 'A1b'], $union);
+
+        $union = $schema->getUnion('A2InheritanceUnion');
+        $this->assertNotNull($union);
+        $this->assertTypes(['A', 'A2', 'A2a'], $union);
+
+        $union = $schema->getUnion('A1aInheritanceUnion');
+        $this->assertNotNull($union);
+        $this->assertTypes(['A', 'A1', 'A1a'], $union);
+
+        $union = $schema->getUnion('A2aInheritanceUnion');
+        $this->assertNotNull($union);
+        $this->assertTypes(['A', 'A2', 'A2a'], $union);
+
+        $schema = new TestSchema();
+        foreach (static::$extra_dataobjects as $class) {
+            $schema->addModelbyClassName($class, function (ModelType $model) {
+                $model->addAllFields();
+            });
+        }
+
+        // Try removing something from the chain
+        $schema->removeModelByClassName(A1::class);
+        $schema->createStoreableSchema();
+        $builder = new InheritanceUnionBuilder($schema);
+        $builder->createUnions();;
+        $union = $schema->getUnion('AInheritanceUnion');
+        $this->assertNotNull($union);
+        $this->assertTypes(['A', 'A2', 'A2a', 'A1a', 'A1b'], $union);
+
+        $union = $schema->getUnion('A1InheritanceUnion');
+        $this->assertNull($union);
+
+        $union = $schema->getUnion('A1aInheritanceUnion');
+        $this->assertNotNull($union);
+        $this->assertTypes(['A', 'A1a'], $union);
+
+        // Sanity check
+        $union = $schema->getUnion('A2aInheritanceUnion');
+        $this->assertNotNull($union);
+        $this->assertTypes(['A', 'A2', 'A2a'], $union);
+
+    }
+
+    public function testApplyUnions()
+    {
+        $schema = new TestSchema();
+        foreach (static::$extra_dataobjects as $class) {
+            $schema->addModelbyClassName($class, function (ModelType $model) {
+                $model->addAllFields();
+                $model->addOperation('read');
+            });
+        }
+        $schema->getModelByClassName(A::class)->addField('allTheB', '[B]');
+        $a = $schema->getModel('A');
+        $interface = new ModelInterfaceType($a->getModel(), 'AInterface');
+        $modelQuery = clone $a->getFieldByName('allTheB');
+        $interface->addField('allTheB', $modelQuery);
+        $schema->addInterface($interface);
+        $a->addInterface('AInterface');
+
+        $schema->createStoreableSchema();
+        $builder = new InheritanceUnionBuilder($schema);
+        $builder->createUnions();
+        $builder->applyUnions();
+
+        $query = $schema->getQueryType()->getFieldByName('readAs');
+        $this->assertNotNull($query);
+        $this->assertEquals('AInheritanceUnion', $query->getNamedType());
+
+        $query = $schema->getQueryType()->getFieldByName('readA1s');
+        $this->assertNotNull($query);
+        $this->assertEquals('A1InheritanceUnion', $query->getNamedType());
+
+        $type = $schema->getModelByClassName(A::class);
+        $nestedQuery = $type->getFieldByName('allTheB');
+        $this->assertNotNull($nestedQuery);
+        $this->assertEquals('BInheritanceUnion', $nestedQuery->getNamedType());
+
+
+        $interface = $schema->getInterface('AInterface');
+        $this->assertEquals('BInheritanceUnion', $interface->getFieldByName('allTheB')->getNamedType());
+
+    }
+
+    public function testUnionName()
+    {
+        $schema = new TestSchema();
+        $this->assertEquals('FooInheritanceUnion', InheritanceUnionBuilder::unionName('Foo', $schema->getConfig()));
+        $schema->applyConfig([
+            'config' => [
+                'inheritanceUnionBuilder' => [
+                    'name_formatter' => 'strrev',
+                ],
+            ],
+        ]);
+        $schema->createStoreableSchema();
+        $this->assertEquals('ooF', InheritanceUnionBuilder::unionName('Foo', $schema->getConfig()));
+    }
+
+    /**
+     * @param array $types
+     * @param UnionType $union
+     */
+    private function assertTypes(array $types, UnionType $union)
+    {
+        $expected = array_map('strtolower', $types);
+        $compare = array_map('strtolower', $union->getTypes());
+
+        $this->assertEmpty(array_diff($expected, $compare));
+        $this->assertEmpty(array_diff($compare, $expected));
+    }
+
+}

--- a/tests/Schema/DataObject/InterfaceBuilderTest.php
+++ b/tests/Schema/DataObject/InterfaceBuilderTest.php
@@ -1,0 +1,184 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
+
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Schema\DataObject\InterfaceBuilder;
+use SilverStripe\GraphQL\Schema\Type\ModelType;
+use SilverStripe\GraphQL\Schema\Type\Type;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1a;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1b;
+
+class InterfaceBuilderTest extends SapphireTest
+{
+    protected static $extra_dataobjects = [
+        A::class,
+        A1::class,
+        A1a::class,
+        A1b::class,
+    ];
+
+    public function testCreateInterfaces()
+    {
+        $schema = new TestSchema();
+        foreach (static::$extra_dataobjects as $class) {
+            $schema->addModelbyClassName($class, function (ModelType $model) {
+                $model->addAllFields();
+            });
+        }
+        $schema->createStoreableSchema();
+        $builder = new InterfaceBuilder($schema);
+        $builder->createInterfaces($schema->getModelByClassName(A::class));
+        $interface = $schema->getInterface('AInterface');
+        $this->assertNotNull($interface);
+        $this->assertFields(['LastEdited', 'Created', 'AField', 'ID'], $interface);
+
+        $interface = $schema->getInterface('A1Interface');
+        $this->assertNotNull($interface);
+        $this->assertFields(['LastEdited', 'Created', 'AField', 'A1Field', 'ID'], $interface);
+
+        $interface = $schema->getInterface('A1aInterface');
+        $this->assertNotNull($interface);
+        $this->assertFields(['LastEdited', 'Created', 'A1Field', 'AField', 'A1aField',  'ID'], $interface);
+
+        $schema = new TestSchema();
+        $schema->applyConfig([
+            'models' => [
+                A::class => [
+                    'fields' => ['AField' => true],
+                ],
+                A1::class => [
+                    'fields' => ['AField' => true],
+                ],
+                A1a::class => [
+                    'fields' => [
+                        'A1aField' => true,
+                        'AField' => true,
+                        'A1Field' => true,
+                    ],
+                ],
+
+            ]
+        ]);
+        $schema->createStoreableSchema();
+
+        $builder = new InterfaceBuilder($schema);
+        $builder->createInterfaces($schema->getModelByClassName(A::class));
+        $interface = $schema->getInterface('AInterface');
+        $this->assertNotNull($interface);
+        $this->assertFields(['AField', 'ID'], $interface);
+
+        // A1 never exposed any of its own fields, so it's just a copy of A
+        $interface = $schema->getInterface('A1Interface');
+        $this->assertNotNull($interface);
+        $this->assertFields(['AField', 'ID'], $interface);
+
+        $interface = $schema->getInterface('A1aInterface');
+        $this->assertNotNull($interface);
+        $this->assertFields(['AField', 'A1aField', 'A1Field', 'ID'], $interface);
+
+        $model = $schema->getModelByClassName(A::class);
+        $this->assertNotNull($model);
+
+        $this->assertInterfaces(['AInterface'], $model);
+
+        $model = $schema->getModelByClassName(A1::class);
+        $this->assertNotNull($model);
+
+        $this->assertInterfaces(['A1Interface', 'AInterface'], $model);
+
+        $model = $schema->getModelByClassName(A1a::class);
+        $this->assertNotNull($model);
+
+        $this->assertInterfaces(['A1Interface', 'AInterface', 'A1aInterface'], $model);
+
+    }
+
+    public function testBaseInterface()
+    {
+        $schema = new TestSchema();
+        foreach (static::$extra_dataobjects as $class) {
+            $schema->addModelbyClassName($class, function (ModelType $model) {
+                $model->addAllFields();
+            });
+        }
+        $schema->createStoreableSchema();
+        $builder = new InterfaceBuilder($schema);
+        $builder->applyBaseInterface();
+        $interface = $schema->getInterface(InterfaceBuilder::BASE_INTERFACE_NAME);
+        $this->assertNotNull($interface);
+        $this->assertFields(['ID'], $interface);
+
+        $schema = new TestSchema();
+        foreach (static::$extra_dataobjects as $class) {
+            $schema->addModelbyClassName($class, function (ModelType $model) {
+                $model->addAllFields();
+            });
+        }
+        $schema->applyConfig([
+            'config' => [
+                'modelConfig' => [
+                    'DataObject' => [
+                        'base_fields' => [
+                            'id' => 'ID',
+                            'lastEdited' => 'String',
+                            'className' => 'String',
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+        $schema->createStoreableSchema();
+        $builder = new InterfaceBuilder($schema);
+        $builder->applyBaseInterface();
+        $interface = $schema->getInterface(InterfaceBuilder::BASE_INTERFACE_NAME);
+        $this->assertNotNull($interface);
+        $this->assertFields(['ID', 'LastEdited', 'ClassName'], $interface);
+    }
+
+    public function testInterfaceName()
+    {
+        $schema = new TestSchema();
+        $this->assertEquals('FooInterface', InterfaceBuilder::interfaceName('Foo', $schema->getConfig()));
+        $schema->applyConfig([
+            'config' => [
+                'interfaceBuilder' => [
+                    'name_formatter' => 'strrev',
+                ],
+            ],
+        ]);
+        $schema->createStoreableSchema();
+        $this->assertEquals('ooF', InterfaceBuilder::interfaceName('Foo', $schema->getConfig()));
+    }
+
+    /**
+     * @param array $fields
+     * @param Type $type
+     */
+    private function assertFields(array $fields, Type $type)
+    {
+        $expected = array_map('strtolower', $fields);
+        $compare = array_map('strtolower', array_keys($type->getFields()));
+
+        $this->assertEmpty(array_diff($expected, $compare));
+        $this->assertEmpty(array_diff($compare, $expected));
+    }
+
+    /**
+     * @param array $fields
+     * @param Type $type
+     */
+    private function assertInterfaces(array $fields, Type $type)
+    {
+        $expected = array_map('strtolower', $fields);
+        $compare = array_map('strtolower', $type->getInterfaces());
+
+        $this->assertEmpty(array_diff($expected, $compare));
+        $this->assertEmpty(array_diff($compare, $expected));
+    }
+
+}

--- a/tests/Schema/DataObject/InterfaceBuilderTest.php
+++ b/tests/Schema/DataObject/InterfaceBuilderTest.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
 
-
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Schema\DataObject\InterfaceBuilder;
 use SilverStripe\GraphQL\Schema\Type\ModelType;
@@ -35,15 +34,15 @@ class InterfaceBuilderTest extends SapphireTest
         $builder->createInterfaces($schema->getModelByClassName(A::class));
         $interface = $schema->getInterface('AInterface');
         $this->assertNotNull($interface);
-        $this->assertFields(['LastEdited', 'Created', 'AField', 'ID'], $interface);
+        $this->assertFields(['LastEdited', 'ClassName', 'Created', 'AField', 'ID'], $interface);
 
         $interface = $schema->getInterface('A1Interface');
         $this->assertNotNull($interface);
-        $this->assertFields(['LastEdited', 'Created', 'AField', 'A1Field', 'ID'], $interface);
+        $this->assertFields(['LastEdited', 'ClassName', 'Created', 'AField', 'A1Field', 'ID'], $interface);
 
         $interface = $schema->getInterface('A1aInterface');
         $this->assertNotNull($interface);
-        $this->assertFields(['LastEdited', 'Created', 'A1Field', 'AField', 'A1aField',  'ID'], $interface);
+        $this->assertFields(['LastEdited', 'ClassName', 'Created', 'A1Field', 'AField', 'A1aField',  'ID'], $interface);
 
         $schema = new TestSchema();
         $schema->applyConfig([
@@ -95,7 +94,6 @@ class InterfaceBuilderTest extends SapphireTest
         $this->assertNotNull($model);
 
         $this->assertInterfaces(['A1Interface', 'AInterface', 'A1aInterface'], $model);
-
     }
 
     public function testBaseInterface()
@@ -180,5 +178,4 @@ class InterfaceBuilderTest extends SapphireTest
         $this->assertEmpty(array_diff($expected, $compare));
         $this->assertEmpty(array_diff($compare, $expected));
     }
-
 }

--- a/tests/Schema/DataObject/Plugin/InheritanceTest.php
+++ b/tests/Schema/DataObject/Plugin/InheritanceTest.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Tests\Schema\DataObject\Plugin;
 
-
 use SilverStripe\Core\Injector\Factory;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
@@ -96,7 +95,6 @@ class InheritanceTest extends SapphireTest
             ['A', 'B', 'C'],
             FakeInterfaceBuilder::$createCalls
         );
-
     }
 
     /**
@@ -111,5 +109,4 @@ class InheritanceTest extends SapphireTest
         $this->assertEmpty(array_diff($expected, $compare));
         $this->assertEmpty(array_diff($compare, $expected));
     }
-
 }

--- a/tests/Schema/DataObject/Plugin/InheritanceTest.php
+++ b/tests/Schema/DataObject/Plugin/InheritanceTest.php
@@ -76,7 +76,7 @@ class InheritanceTest extends SapphireTest
                 'class' => FakeInheritanceUnionBuilder::class,
             ],
         ]);
-        Inheritance::updateSchema($schema);
+        Inheritance::updateSchema($schema, []);
 
         $this->assertTrue(FakeInterfaceBuilder::$baseCalled);
         $this->assertTrue(FakeInheritanceUnionBuilder::$createCalled);

--- a/tests/Schema/DataObject/Plugin/InheritanceTest.php
+++ b/tests/Schema/DataObject/Plugin/InheritanceTest.php
@@ -1,0 +1,444 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Schema\DataObject\Plugin;
+
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\GraphQL\Schema\DataObject\ModelCreator;
+use SilverStripe\GraphQL\Schema\DataObject\Plugin\Inheritance;
+use SilverStripe\GraphQL\Schema\DataObject\ReadCreator;
+use SilverStripe\GraphQL\Schema\Interfaces\SchemaComponent;
+use SilverStripe\GraphQL\Schema\Schema;
+use SilverStripe\GraphQL\Schema\SchemaConfig;
+use SilverStripe\GraphQL\Schema\Type\ModelType;
+use SilverStripe\GraphQL\Schema\Type\Type;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1a;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A1b;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A2;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\A2a;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B1;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B1a;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B1b;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\B2;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\C;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\C1;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\C2;
+use SilverStripe\GraphQL\Tests\Fake\Inheritance\C2a;
+
+class InheritanceTest extends SapphireTest
+{
+    protected static $extra_dataobjects = [
+        A::class,
+        A1::class,
+        A1a::class,
+        A1b::class,
+        A2::class,
+        A2a::class,
+        B::class,
+        B1::class,
+        B1a::class,
+        B1b::class,
+        B2::class,
+        C::class,
+        C1::class,
+        C2::class,
+        C2a::class,
+    ];
+
+    public function testFillAncestry()
+    {
+        $schema = $this->createSchema();
+
+        // A1 and A are not in this schema, because only the A1a descendant
+        // has been exposed for reading.
+        $schema->applyConfig([
+            'models' => [
+                A1a::class => [
+                    'fields' => [
+                        'A1aField' => true,
+                        'AField' => true,
+                    ],
+                    'operations' => ['read' => true],
+                ],
+            ],
+        ]);
+        $schema->createStoreableSchema();
+
+        Inheritance::updateSchema($schema);
+        $a1a = $schema->getModelByClassName(A1a::class);
+        $this->assertNotNull($a1a);
+        $this->assertFields(['A1aField', 'AField', 'id'], $a1a);
+
+        $a1 = $schema->getModelByClassName(A1::class);
+        $this->assertNull($a1);
+        $a = $schema->getModelByClassName(A::class);
+        $this->assertNull($a);
+
+        $schema = $this->createSchema();
+
+        // Now A and A1 will be exposed because A is the base model, having
+        // a read operation
+        $schema->applyConfig([
+            'models' => [
+                A::class => [
+                    'operations' => ['read' => true],
+                ],
+                A1a::class => [
+                    'fields' => [
+                        'A1aField' => true,
+                        'AField' => true,
+                    ],
+                    'operations' => ['read' => true],
+                ],
+            ],
+        ]);
+        $schema->createStoreableSchema();
+
+        Inheritance::updateSchema($schema);
+        $a1a = $schema->getModelByClassName(A1a::class);
+        $this->assertNotNull($a1a);
+        $this->assertFields(['A1aField', 'AField', 'id'], $a1a);
+
+        $a1 = $schema->getModelByClassName(A1::class);
+        $this->assertNotNull($a1);
+        $this->assertFields(['AField', 'id'], $a1);
+        $a = $schema->getModelByClassName(A::class);
+        $this->assertNotNull($a);
+        $this->assertFields(['AField', 'id'], $a1);
+    }
+
+    public function testFillDescendants()
+    {
+        $schema = $this->createSchema();
+        $schema->applyConfig([
+            'models' => [
+                A::class => [
+                    'fields' => [
+                        'AField' => true,
+                    ],
+                    'operations' => ['read' => true],
+                ],
+                A1::class => [
+                    'fields' => [
+                        'A1Field' => true,
+                    ],
+                ],
+                B::class => [
+                    'fields' => [
+                        'BField' => true,
+                    ],
+                    'operations' => ['read' => true],
+                ],
+                B1a::class => [
+                    'fields' => [
+                        'B1aField' => true,
+                        'B1Field' => true,
+                    ],
+                ],
+                C::class => [
+                    'fields' => [
+                        'CField' => true,
+                    ],
+                    'operations' => ['read' => true],
+                ],
+                C2a::class => [
+                    'fields' => [
+                        'C2aField' => true,
+                        'C2Field' => true,
+                    ],
+                ],
+
+            ],
+        ]);
+        $schema->createStoreableSchema();
+
+        Inheritance::updateSchema($schema);
+        $a = $schema->getModelByClassName(A::class);
+        $this->assertNotNull($a);
+        $this->assertFields(['AField', 'id'], $a);
+        $a1 = $schema->getModelByClassName(A1::class);
+        $this->assertNotNull($a1);
+        $this->assertFields(['A1Field', 'AField', 'id'], $a1);
+
+        // This descendant shouldn't be added implicitly, because it was never
+        // assigned any fields or operations.
+        $this->assertNull($schema->getModelByClassName(A1a::class));
+
+        $b = $schema->getModelByClassName(B::class);
+        $this->assertNotNull($b);
+        $this->assertFields(['BField', 'id'], $b);
+
+        // B1 should have been implicitly added, because B1a was
+        $b1 = $schema->getModelByClassName(B1::class);
+        $this->assertNotNull($b1);
+        // B1 has no native fields, but its descendant is, so all
+        // it has is its inherited fields from B
+        $this->assertFields(['BField', 'id'], $b1);
+
+        $b1a = $schema->getModelByClassName(B1a::class);
+        $this->assertNotNull($b1a);
+        // Its native fields were added by its descendant B1a
+        $this->assertFields(['B1aField', 'B1Field', 'BField', 'id'], $b1a);
+
+        $c = $schema->getModelByClassName(C::class);
+        $this->assertNotNull($c);
+        $this->assertFields(['CField', 'id'], $c);
+
+        // Sanity check -- no siblings.
+        $this->assertNull($schema->getModelByClassName(C1::class));
+
+        // B1 should have been implicitly added, because B1a was
+        $c2 = $schema->getModelByClassName(C2::class);
+        $this->assertNotNull($c2);
+        // C2 gets its native field added by its descendant C2a
+        $this->assertFields(['C2Field', 'CField', 'id'], $c2);
+
+        $c2a = $schema->getModelByClassName(C2a::class);
+        $this->assertNotNull($c2a);
+        $this->assertFields(['C2aField', 'C2Field', 'CField', 'id'], $c2a);
+    }
+
+    public function testCreatesInterfaces()
+    {
+        $schema = $this->createSchema();
+
+        // Leave out a couple classes to test implicit adding
+        $classes = array_filter(static::$extra_dataobjects, function ($class) {
+            return !in_array($class, [A2a::class, C2::class]);
+        });
+        foreach ($classes as $class) {
+            $schema->addModelbyClassName($class, function (ModelType $type) {
+                $type->addAllFields();
+                $type->addOperation('read');
+            });
+        }
+        $schema->createStoreableSchema();
+        Inheritance::updateSchema($schema);
+
+        $a1a = $schema->getModelByClassName(A1a::class);
+        $this->assertNotNull($a1a);
+        // A1a is a leaf. No interface.
+        $this->assertNull($schema->getInterface(Inheritance::modelToInterface($a1a)));
+        $this->assertInterfaces(['DataObjectInterface', 'A1Interface', 'AInterface'], $a1a);
+
+        $a1 = $schema->getModelByClassName(A1::class);
+        $this->assertNotNull($a1);
+        $interface = $schema->getInterface(Inheritance::modelToInterface($a1));
+        $this->assertNotNull($interface);
+        $this->assertFields(['A1Field'], $interface);
+        $this->assertInterfaces(['DataObjectInterface', 'A1Interface', 'AInterface'], $a1);
+
+        $a = $schema->getModelByClassName(A::class);
+        $this->assertNotNull($a);
+        $interface = $schema->getInterface(Inheritance::modelToInterface($a));
+        $this->assertNotNull($interface);
+        $this->assertFields(['AField'], $interface);
+        $this->assertInterfaces(['DataObjectInterface', 'AInterface'], $a);
+
+        $this->assertNull($schema->getModelByClassName(A2a::class));
+        $this->assertNull($schema->getInterface('A2aInterface'));
+
+        $a2 = $schema->getModelByClassName(A2::class);
+        $this->assertNotNull($a2);
+        $interface = $schema->getInterface(Inheritance::modelToInterface($a2));
+        // There is no interface for A2 because it's a leaf. A2a was never added.
+        $this->assertNull($interface);
+        $this->assertInterfaces(['DataObjectInterface', 'AInterface'], $a2);
+
+        $b1a = $schema->getModelByClassName(B1a::class);
+        $this->assertNotNull($b1a);
+        $interface = $schema->getInterface(Inheritance::modelToInterface($b1a));
+        $this->assertNull($interface);
+        $this->assertInterfaces(['DataObjectInterface', 'BInterface'], $b1a);
+
+        $b1 = $schema->getModelByClassName(B1::class);
+        $this->assertNotNull($b1);
+        $interface = $schema->getInterface(Inheritance::modelToInterface($b1));
+        $this->assertNull($interface);
+
+        $b = $schema->getModelByClassName(B::class);
+        $this->assertNotNull($b);
+        $interface = $schema->getInterface(Inheritance::modelToInterface($b));
+        $this->assertNotNull($interface);
+        $this->assertFields(['BField'], $interface);
+        $this->assertInterfaces(['DataObjectInterface', 'BInterface'], $b);
+
+        $b1b = $schema->getModelByClassName(B1b::class);
+        $this->assertNotNull($b1b);
+        $interface = $schema->getInterface(Inheritance::modelToInterface($b1b));
+        $this->assertNull($interface);
+        $this->assertInterfaces(['DataObjectInterface', 'BInterface'], $b1b);
+
+        $c1 = $schema->getModelByClassName(C1::class);
+        $this->assertNotNull($c1);
+        $interface = $schema->getInterface(Inheritance::modelToInterface($c1));
+        $this->assertNull($interface);
+        $this->assertInterfaces(['DataObjectInterface', 'CInterface'], $c1);
+
+        $c2a = $schema->getModelByClassName(C2a::class);
+        $this->assertNotNull($c2a);
+        $interface = $schema->getInterface(Inheritance::modelToInterface($c2a));
+        $this->assertNull($interface);
+        $this->assertInterfaces(['DataObjectInterface', 'C2Interface', 'CInterface'], $c2a);
+
+        $c2 = $schema->getModelByClassName(C2::class);
+        $this->assertNotNull($c2);
+        $interface = $schema->getInterface(Inheritance::modelToInterface($c2));
+        $this->assertFields(['C2Field'], $interface);
+        $this->assertInterfaces(['DataObjectInterface', 'C2Interface', 'CInterface'], $c2);
+    }
+
+    public function testBaseInterface()
+    {
+        $schema = $this->createSchema();
+
+        foreach (static::$extra_dataobjects as $class) {
+            $schema->addModelbyClassName($class, function (ModelType $type) {
+                $type->addAllFields();
+                $type->addOperation('read');
+            });
+        }
+        $schema->createStoreableSchema();
+        Inheritance::updateSchema($schema);
+
+        $base = $schema->getInterface('DataObjectInterface');
+        $this->assertNotNull($base);
+        $this->assertFields(['lastEdited', 'created', 'id'], $base);
+
+        foreach ($schema->getModels() as $model) {
+            $this->assertContains('DataObjectInterface', $model->getInterfaces());
+        }
+    }
+
+    public function testUnions()
+    {
+        $schema = $this->createSchema();
+
+        // Leave out a couple classes to test implicit adding
+        $classes = array_filter(static::$extra_dataobjects, function ($class) {
+            return !in_array($class, [A2a::class, C2::class]);
+        });
+        foreach ($classes as $class) {
+            $schema->addModelbyClassName($class, function (ModelType $type) {
+                $type->addAllFields();
+                $type->addOperation('read');
+            });
+        }
+        $schema->createStoreableSchema();
+        Inheritance::updateSchema($schema);
+
+        $union = $schema->getUnion('AInheritanceUnion');
+        $this->assertNotNull($union);
+        $types = $union->getTypes();
+        $this->assertCount(5, $types);
+        $this->assertContains('A', $types);
+        $this->assertContains('A1', $types);
+        $this->assertContains('A2', $types);
+        $this->assertContains('A1a', $types);
+        $this->assertContains('A1b', $types);
+        $this->assertNotContains('A2a', $types);
+        $this->assertNotContains('B', $types);
+
+        $union = $schema->getUnion('A1InheritanceUnion');
+        $this->assertNotNull($union);
+        $types = $union->getTypes();
+        $this->assertCount(3, $types);
+        $this->assertContains('A1', $types);
+        $this->assertContains('A1a', $types);
+        $this->assertContains('A1b', $types);
+        $this->assertNotContains('A2a', $types);
+
+        $union = $schema->getUnion('A2InheritanceUnion');
+        $this->assertNull($union);
+
+        $union = $schema->getUnion('BInheritanceUnion');
+        $this->assertNotNull($union);
+        $types = $union->getTypes();
+        $this->assertCount(5, $types);
+        $this->assertContains('B', $types);
+        $this->assertContains('B1', $types);
+        $this->assertContains('B2', $types);
+        $this->assertContains('B1a', $types);
+        $this->assertContains('B1b', $types);
+        $this->assertNotContains('A', $types);
+
+        // B1 has no fields
+        $union = $schema->getUnion('B1InheritanceUnion');
+        $this->assertNull($union);
+
+        // B2 has no descendants
+        $union = $schema->getUnion('B2InheritanceUnion');
+        $this->assertNull($union);
+
+        $union = $schema->getUnion('CInheritanceUnion');
+        $this->assertNotNull($union);
+        $types = $union->getTypes();
+        $this->assertCount(4, $types);
+        $this->assertContains('C', $types);
+        $this->assertContains('C1', $types);
+        $this->assertContains('C2', $types);
+        $this->assertContains('C2a', $types);
+
+        $union = $schema->getUnion('C2InheritanceUnion');
+        $this->assertNotNull($union);
+        $types = $union->getTypes();
+        $this->assertCount(2, $types);
+        $this->assertContains('C2', $types);
+        $this->assertContains('C2a', $types);
+
+    }
+
+    /**
+     * @param array $fields
+     * @param Type $type
+     */
+    private function assertFields(array $fields, Type $type)
+    {
+        $compare = array_map('strtolower', array_keys($type->getFields()));
+        // Alpha sort with all these A1 A1a type fields isn't intuitive, so
+        // strlen FTW
+        usort($compare, function ($a, $b) {
+            return strlen($b) <=> strlen($a);
+        });
+
+        $this->assertEquals(array_map('strtolower', $fields), $compare);
+    }
+
+    /**
+     * @param array $expected
+     * @param Type $type
+     */
+    private function assertInterfaces(array $expected, Type $type)
+    {
+        $interfaces = $type->getInterfaces();
+        $this->assertCount(count($expected), $interfaces);
+        usort($interfaces, function ($a, $b) {
+            return strlen($b) <=> strlen($a);
+        });
+        $this->assertEquals($expected, $interfaces);
+    }
+
+    /**
+     * @return Schema
+     */
+    private function createSchema(): Schema
+    {
+        $schema = Schema::create('test', new SchemaConfig([
+            'modelCreators' => [ ModelCreator::class ],
+            'modelConfig' => [
+                'DataObject' => [
+                    'operations' => [
+                        'read' => [
+                            'class' => ReadCreator::class,
+                        ],
+                    ],
+                ],
+            ]
+        ]));
+        return $schema;
+    }
+}

--- a/tests/Schema/DataObject/Plugin/InheritanceTest.php
+++ b/tests/Schema/DataObject/Plugin/InheritanceTest.php
@@ -4,13 +4,14 @@
 namespace SilverStripe\GraphQL\Tests\Schema\DataObject\Plugin;
 
 
+use SilverStripe\Core\Injector\Factory;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\GraphQL\Schema\DataObject\ModelCreator;
+use SilverStripe\GraphQL\Schema\DataObject\InheritanceBuilder;
+use SilverStripe\GraphQL\Schema\DataObject\InheritanceUnionBuilder;
+use SilverStripe\GraphQL\Schema\DataObject\InterfaceBuilder;
 use SilverStripe\GraphQL\Schema\DataObject\Plugin\Inheritance;
-use SilverStripe\GraphQL\Schema\DataObject\ReadCreator;
-use SilverStripe\GraphQL\Schema\Interfaces\SchemaComponent;
 use SilverStripe\GraphQL\Schema\Schema;
-use SilverStripe\GraphQL\Schema\SchemaConfig;
 use SilverStripe\GraphQL\Schema\Type\ModelType;
 use SilverStripe\GraphQL\Schema\Type\Type;
 use SilverStripe\GraphQL\Tests\Fake\Inheritance\A;
@@ -28,9 +29,14 @@ use SilverStripe\GraphQL\Tests\Fake\Inheritance\C;
 use SilverStripe\GraphQL\Tests\Fake\Inheritance\C1;
 use SilverStripe\GraphQL\Tests\Fake\Inheritance\C2;
 use SilverStripe\GraphQL\Tests\Fake\Inheritance\C2a;
+use SilverStripe\GraphQL\Tests\Schema\DataObject\FakeInheritanceBuilder;
+use SilverStripe\GraphQL\Tests\Schema\DataObject\FakeInheritanceUnionBuilder;
+use SilverStripe\GraphQL\Tests\Schema\DataObject\FakeInterfaceBuilder;
+use SilverStripe\GraphQL\Tests\Schema\DataObject\TestSchema;
 
 class InheritanceTest extends SapphireTest
 {
+
     protected static $extra_dataobjects = [
         A::class,
         A1::class,
@@ -49,396 +55,61 @@ class InheritanceTest extends SapphireTest
         C2a::class,
     ];
 
-    public function testFillAncestry()
+
+    public function testInheritance()
     {
-        $schema = $this->createSchema();
-
-        // A1 and A are not in this schema, because only the A1a descendant
-        // has been exposed for reading.
-        $schema->applyConfig([
-            'models' => [
-                A1a::class => [
-                    'fields' => [
-                        'A1aField' => true,
-                        'AField' => true,
-                    ],
-                    'operations' => ['read' => true],
-                ],
-            ],
-        ]);
-        $schema->createStoreableSchema();
-
-        Inheritance::updateSchema($schema);
-        $a1a = $schema->getModelByClassName(A1a::class);
-        $this->assertNotNull($a1a);
-        $this->assertFields(['A1aField', 'AField', 'id'], $a1a);
-
-        $a1 = $schema->getModelByClassName(A1::class);
-        $this->assertNull($a1);
-        $a = $schema->getModelByClassName(A::class);
-        $this->assertNull($a);
-
-        $schema = $this->createSchema();
-
-        // Now A and A1 will be exposed because A is the base model, having
-        // a read operation
-        $schema->applyConfig([
-            'models' => [
-                A::class => [
-                    'operations' => ['read' => true],
-                ],
-                A1a::class => [
-                    'fields' => [
-                        'A1aField' => true,
-                        'AField' => true,
-                    ],
-                    'operations' => ['read' => true],
-                ],
-            ],
-        ]);
-        $schema->createStoreableSchema();
-
-        Inheritance::updateSchema($schema);
-        $a1a = $schema->getModelByClassName(A1a::class);
-        $this->assertNotNull($a1a);
-        $this->assertFields(['A1aField', 'AField', 'id'], $a1a);
-
-        $a1 = $schema->getModelByClassName(A1::class);
-        $this->assertNotNull($a1);
-        $this->assertFields(['AField', 'id'], $a1);
-        $a = $schema->getModelByClassName(A::class);
-        $this->assertNotNull($a);
-        $this->assertFields(['AField', 'id'], $a1);
-    }
-
-    public function testFillDescendants()
-    {
-        $schema = $this->createSchema();
-        $schema->applyConfig([
-            'models' => [
-                A::class => [
-                    'fields' => [
-                        'AField' => true,
-                    ],
-                    'operations' => ['read' => true],
-                ],
-                A1::class => [
-                    'fields' => [
-                        'A1Field' => true,
-                    ],
-                ],
-                B::class => [
-                    'fields' => [
-                        'BField' => true,
-                    ],
-                    'operations' => ['read' => true],
-                ],
-                B1a::class => [
-                    'fields' => [
-                        'B1aField' => true,
-                        'B1Field' => true,
-                    ],
-                ],
-                C::class => [
-                    'fields' => [
-                        'CField' => true,
-                    ],
-                    'operations' => ['read' => true],
-                ],
-                C2a::class => [
-                    'fields' => [
-                        'C2aField' => true,
-                        'C2Field' => true,
-                    ],
-                ],
-
-            ],
-        ]);
-        $schema->createStoreableSchema();
-
-        Inheritance::updateSchema($schema);
-        $a = $schema->getModelByClassName(A::class);
-        $this->assertNotNull($a);
-        $this->assertFields(['AField', 'id'], $a);
-        $a1 = $schema->getModelByClassName(A1::class);
-        $this->assertNotNull($a1);
-        $this->assertFields(['A1Field', 'AField', 'id'], $a1);
-
-        // This descendant shouldn't be added implicitly, because it was never
-        // assigned any fields or operations.
-        $this->assertNull($schema->getModelByClassName(A1a::class));
-
-        $b = $schema->getModelByClassName(B::class);
-        $this->assertNotNull($b);
-        $this->assertFields(['BField', 'id'], $b);
-
-        // B1 should have been implicitly added, because B1a was
-        $b1 = $schema->getModelByClassName(B1::class);
-        $this->assertNotNull($b1);
-        // B1 has no native fields, but its descendant is, so all
-        // it has is its inherited fields from B
-        $this->assertFields(['BField', 'id'], $b1);
-
-        $b1a = $schema->getModelByClassName(B1a::class);
-        $this->assertNotNull($b1a);
-        // Its native fields were added by its descendant B1a
-        $this->assertFields(['B1aField', 'B1Field', 'BField', 'id'], $b1a);
-
-        $c = $schema->getModelByClassName(C::class);
-        $this->assertNotNull($c);
-        $this->assertFields(['CField', 'id'], $c);
-
-        // Sanity check -- no siblings.
-        $this->assertNull($schema->getModelByClassName(C1::class));
-
-        // B1 should have been implicitly added, because B1a was
-        $c2 = $schema->getModelByClassName(C2::class);
-        $this->assertNotNull($c2);
-        // C2 gets its native field added by its descendant C2a
-        $this->assertFields(['C2Field', 'CField', 'id'], $c2);
-
-        $c2a = $schema->getModelByClassName(C2a::class);
-        $this->assertNotNull($c2a);
-        $this->assertFields(['C2aField', 'C2Field', 'CField', 'id'], $c2a);
-    }
-
-    public function testCreatesInterfaces()
-    {
-        $schema = $this->createSchema();
-
-        // Leave out a couple classes to test implicit adding
-        $classes = array_filter(static::$extra_dataobjects, function ($class) {
-            return !in_array($class, [A2a::class, C2::class]);
-        });
-        foreach ($classes as $class) {
-            $schema->addModelbyClassName($class, function (ModelType $type) {
-                $type->addAllFields();
-                $type->addOperation('read');
-            });
-        }
-        $schema->createStoreableSchema();
-        Inheritance::updateSchema($schema);
-
-        $a1a = $schema->getModelByClassName(A1a::class);
-        $this->assertNotNull($a1a);
-        // A1a is a leaf. No interface.
-        $this->assertNull($schema->getInterface(Inheritance::interfaceName($a1a->getName())));
-        $this->assertInterfaces(['DataObjectInterface', 'A1Interface', 'AInterface'], $a1a);
-
-        $a1 = $schema->getModelByClassName(A1::class);
-        $this->assertNotNull($a1);
-        $interface = $schema->getInterface(Inheritance::interfaceName($a1->getName()));
-        $this->assertNotNull($interface);
-        $this->assertFields(['A1Field'], $interface);
-        $this->assertInterfaces(['DataObjectInterface', 'A1Interface', 'AInterface'], $a1);
-
-        $a = $schema->getModelByClassName(A::class);
-        $this->assertNotNull($a);
-        $interface = $schema->getInterface(Inheritance::interfaceName($a->getName()));
-        $this->assertNotNull($interface);
-        $this->assertFields(['AField'], $interface);
-        $this->assertInterfaces(['DataObjectInterface', 'AInterface'], $a);
-
-        $this->assertNull($schema->getModelByClassName(A2a::class));
-        $this->assertNull($schema->getInterface('A2aInterface'));
-
-        $a2 = $schema->getModelByClassName(A2::class);
-        $this->assertNotNull($a2);
-        $interface = $schema->getInterface(Inheritance::interfaceName($a2->getName()));
-        // There is no interface for A2 because it's a leaf. A2a was never added.
-        $this->assertNull($interface);
-        $this->assertInterfaces(['DataObjectInterface', 'AInterface'], $a2);
-
-        $b1a = $schema->getModelByClassName(B1a::class);
-        $this->assertNotNull($b1a);
-        $interface = $schema->getInterface(Inheritance::interfaceName($b1a->getName()));
-        $this->assertNull($interface);
-        $this->assertInterfaces(['DataObjectInterface', 'BInterface'], $b1a);
-
-        $b1 = $schema->getModelByClassName(B1::class);
-        $this->assertNotNull($b1);
-        $interface = $schema->getInterface(Inheritance::interfaceName($b1->getName()));
-        $this->assertNull($interface);
-
-        $b = $schema->getModelByClassName(B::class);
-        $this->assertNotNull($b);
-        $interface = $schema->getInterface(Inheritance::interfaceName($b->getName()));
-        $this->assertNotNull($interface);
-        $this->assertFields(['BField'], $interface);
-        $this->assertInterfaces(['DataObjectInterface', 'BInterface'], $b);
-
-        $b1b = $schema->getModelByClassName(B1b::class);
-        $this->assertNotNull($b1b);
-        $interface = $schema->getInterface(Inheritance::interfaceName($b1b->getName()));
-        $this->assertNull($interface);
-        $this->assertInterfaces(['DataObjectInterface', 'BInterface'], $b1b);
-
-        $c1 = $schema->getModelByClassName(C1::class);
-        $this->assertNotNull($c1);
-        $interface = $schema->getInterface(Inheritance::interfaceName($c1->getName()));
-        $this->assertNull($interface);
-        $this->assertInterfaces(['DataObjectInterface', 'CInterface'], $c1);
-
-        $c2a = $schema->getModelByClassName(C2a::class);
-        $this->assertNotNull($c2a);
-        $interface = $schema->getInterface(Inheritance::interfaceName($c2a->getName()));
-        $this->assertNull($interface);
-        $this->assertInterfaces(['DataObjectInterface', 'C2Interface', 'CInterface'], $c2a);
-
-        $c2 = $schema->getModelByClassName(C2::class);
-        $this->assertNotNull($c2);
-        $interface = $schema->getInterface(Inheritance::interfaceName($c2->getName()));
-        $this->assertFields(['C2Field'], $interface);
-        $this->assertInterfaces(['DataObjectInterface', 'C2Interface', 'CInterface'], $c2);
-    }
-
-    public function testBaseInterface()
-    {
-        $schema = $this->createSchema();
-
+        $schema = new TestSchema();
         foreach (static::$extra_dataobjects as $class) {
             $schema->addModelbyClassName($class, function (ModelType $type) {
                 $type->addAllFields();
-                $type->addOperation('read');
             });
         }
         $schema->createStoreableSchema();
+
+        Injector::inst()->load([
+            InheritanceBuilder::class => [
+                'class' => FakeInheritanceBuilder::class,
+            ],
+            InterfaceBuilder::class => [
+                'class' => FakeInterfaceBuilder::class,
+            ],
+            InheritanceUnionBuilder::class => [
+                'class' => FakeInheritanceUnionBuilder::class,
+            ],
+        ]);
         Inheritance::updateSchema($schema);
 
-        $base = $schema->getInterface('DataObjectInterface');
-        $this->assertNotNull($base);
-        $this->assertFields(['lastEdited', 'created', 'id'], $base);
+        $this->assertTrue(FakeInterfaceBuilder::$baseCalled);
+        $this->assertTrue(FakeInheritanceUnionBuilder::$createCalled);
+        $this->assertTrue(FakeInheritanceUnionBuilder::$applyCalled);
 
-        foreach ($schema->getModels() as $model) {
-            $this->assertContains('DataObjectInterface', $model->getInterfaces());
-        }
-    }
+        $this->assertCalls(
+            ['A1a', 'A1b', 'A2a', 'B1a', 'B1b', 'B2', 'C1', 'C2a'],
+            FakeInheritanceBuilder::$ancestryCalls
+        );
+        $this->assertCalls(
+            ['A', 'B', 'C'],
+            FakeInheritanceBuilder::$descendantCalls
+        );
 
-    public function testUnions()
-    {
-        $schema = $this->createSchema();
+        $this->assertCalls(
+            ['A', 'B', 'C'],
+            FakeInterfaceBuilder::$createCalls
+        );
 
-        // Leave out a couple classes to test implicit adding
-        $classes = array_filter(static::$extra_dataobjects, function ($class) {
-            return !in_array($class, [A2a::class, C2::class]);
-        });
-        foreach ($classes as $class) {
-            $schema->addModelbyClassName($class, function (ModelType $type) {
-                $type->addAllFields();
-                $type->addOperation('read');
-            });
-        }
-        $schema->createStoreableSchema();
-        Inheritance::updateSchema($schema);
-
-        $union = $schema->getUnion('AInheritanceUnion');
-        $this->assertNotNull($union);
-        $types = $union->getTypes();
-        $this->assertCount(5, $types);
-        $this->assertContains('A', $types);
-        $this->assertContains('A1', $types);
-        $this->assertContains('A2', $types);
-        $this->assertContains('A1a', $types);
-        $this->assertContains('A1b', $types);
-        $this->assertNotContains('A2a', $types);
-        $this->assertNotContains('B', $types);
-
-        $union = $schema->getUnion('A1InheritanceUnion');
-        $this->assertNotNull($union);
-        $types = $union->getTypes();
-        $this->assertCount(3, $types);
-        $this->assertContains('A1', $types);
-        $this->assertContains('A1a', $types);
-        $this->assertContains('A1b', $types);
-        $this->assertNotContains('A2a', $types);
-
-        $union = $schema->getUnion('A2InheritanceUnion');
-        $this->assertNull($union);
-
-        $union = $schema->getUnion('BInheritanceUnion');
-        $this->assertNotNull($union);
-        $types = $union->getTypes();
-        $this->assertCount(5, $types);
-        $this->assertContains('B', $types);
-        $this->assertContains('B1', $types);
-        $this->assertContains('B2', $types);
-        $this->assertContains('B1a', $types);
-        $this->assertContains('B1b', $types);
-        $this->assertNotContains('A', $types);
-
-        // B1 has no fields
-        $union = $schema->getUnion('B1InheritanceUnion');
-        $this->assertNull($union);
-
-        // B2 has no descendants
-        $union = $schema->getUnion('B2InheritanceUnion');
-        $this->assertNull($union);
-
-        $union = $schema->getUnion('CInheritanceUnion');
-        $this->assertNotNull($union);
-        $types = $union->getTypes();
-        $this->assertCount(4, $types);
-        $this->assertContains('C', $types);
-        $this->assertContains('C1', $types);
-        $this->assertContains('C2', $types);
-        $this->assertContains('C2a', $types);
-
-        $union = $schema->getUnion('C2InheritanceUnion');
-        $this->assertNotNull($union);
-        $types = $union->getTypes();
-        $this->assertCount(2, $types);
-        $this->assertContains('C2', $types);
-        $this->assertContains('C2a', $types);
-
-    }
-
-    /**
-     * @param array $fields
-     * @param Type $type
-     */
-    private function assertFields(array $fields, Type $type)
-    {
-        $compare = array_map('strtolower', array_keys($type->getFields()));
-        // Alpha sort with all these A1 A1a type fields isn't intuitive, so
-        // strlen FTW
-        usort($compare, function ($a, $b) {
-            return strlen($b) <=> strlen($a);
-        });
-
-        $this->assertEquals(array_map('strtolower', $fields), $compare);
     }
 
     /**
      * @param array $expected
-     * @param Type $type
+     * @param array $actual
      */
-    private function assertInterfaces(array $expected, Type $type)
+    private function assertCalls(array $expected, array $actual)
     {
-        $interfaces = $type->getInterfaces();
-        $this->assertCount(count($expected), $interfaces);
-        usort($interfaces, function ($a, $b) {
-            return strlen($b) <=> strlen($a);
-        });
-        $this->assertEquals($expected, $interfaces);
+        $expected = array_map('strtolower', $expected);
+        $compare = array_map('strtolower', array_keys($actual));
+
+        $this->assertEmpty(array_diff($expected, $compare));
+        $this->assertEmpty(array_diff($compare, $expected));
     }
 
-    /**
-     * @return Schema
-     */
-    private function createSchema(): Schema
-    {
-        $schema = Schema::create('test', new SchemaConfig([
-            'modelCreators' => [ ModelCreator::class ],
-            'modelConfig' => [
-                'DataObject' => [
-                    'operations' => [
-                        'read' => [
-                            'class' => ReadCreator::class,
-                        ],
-                    ],
-                ],
-            ]
-        ]));
-        return $schema;
-    }
 }

--- a/tests/Schema/DataObject/Plugin/InheritanceTest.php
+++ b/tests/Schema/DataObject/Plugin/InheritanceTest.php
@@ -222,19 +222,19 @@ class InheritanceTest extends SapphireTest
         $a1a = $schema->getModelByClassName(A1a::class);
         $this->assertNotNull($a1a);
         // A1a is a leaf. No interface.
-        $this->assertNull($schema->getInterface(Inheritance::modelToInterface($a1a)));
+        $this->assertNull($schema->getInterface(Inheritance::interfaceName($a1a->getName())));
         $this->assertInterfaces(['DataObjectInterface', 'A1Interface', 'AInterface'], $a1a);
 
         $a1 = $schema->getModelByClassName(A1::class);
         $this->assertNotNull($a1);
-        $interface = $schema->getInterface(Inheritance::modelToInterface($a1));
+        $interface = $schema->getInterface(Inheritance::interfaceName($a1->getName()));
         $this->assertNotNull($interface);
         $this->assertFields(['A1Field'], $interface);
         $this->assertInterfaces(['DataObjectInterface', 'A1Interface', 'AInterface'], $a1);
 
         $a = $schema->getModelByClassName(A::class);
         $this->assertNotNull($a);
-        $interface = $schema->getInterface(Inheritance::modelToInterface($a));
+        $interface = $schema->getInterface(Inheritance::interfaceName($a->getName()));
         $this->assertNotNull($interface);
         $this->assertFields(['AField'], $interface);
         $this->assertInterfaces(['DataObjectInterface', 'AInterface'], $a);
@@ -244,50 +244,50 @@ class InheritanceTest extends SapphireTest
 
         $a2 = $schema->getModelByClassName(A2::class);
         $this->assertNotNull($a2);
-        $interface = $schema->getInterface(Inheritance::modelToInterface($a2));
+        $interface = $schema->getInterface(Inheritance::interfaceName($a2->getName()));
         // There is no interface for A2 because it's a leaf. A2a was never added.
         $this->assertNull($interface);
         $this->assertInterfaces(['DataObjectInterface', 'AInterface'], $a2);
 
         $b1a = $schema->getModelByClassName(B1a::class);
         $this->assertNotNull($b1a);
-        $interface = $schema->getInterface(Inheritance::modelToInterface($b1a));
+        $interface = $schema->getInterface(Inheritance::interfaceName($b1a->getName()));
         $this->assertNull($interface);
         $this->assertInterfaces(['DataObjectInterface', 'BInterface'], $b1a);
 
         $b1 = $schema->getModelByClassName(B1::class);
         $this->assertNotNull($b1);
-        $interface = $schema->getInterface(Inheritance::modelToInterface($b1));
+        $interface = $schema->getInterface(Inheritance::interfaceName($b1->getName()));
         $this->assertNull($interface);
 
         $b = $schema->getModelByClassName(B::class);
         $this->assertNotNull($b);
-        $interface = $schema->getInterface(Inheritance::modelToInterface($b));
+        $interface = $schema->getInterface(Inheritance::interfaceName($b->getName()));
         $this->assertNotNull($interface);
         $this->assertFields(['BField'], $interface);
         $this->assertInterfaces(['DataObjectInterface', 'BInterface'], $b);
 
         $b1b = $schema->getModelByClassName(B1b::class);
         $this->assertNotNull($b1b);
-        $interface = $schema->getInterface(Inheritance::modelToInterface($b1b));
+        $interface = $schema->getInterface(Inheritance::interfaceName($b1b->getName()));
         $this->assertNull($interface);
         $this->assertInterfaces(['DataObjectInterface', 'BInterface'], $b1b);
 
         $c1 = $schema->getModelByClassName(C1::class);
         $this->assertNotNull($c1);
-        $interface = $schema->getInterface(Inheritance::modelToInterface($c1));
+        $interface = $schema->getInterface(Inheritance::interfaceName($c1->getName()));
         $this->assertNull($interface);
         $this->assertInterfaces(['DataObjectInterface', 'CInterface'], $c1);
 
         $c2a = $schema->getModelByClassName(C2a::class);
         $this->assertNotNull($c2a);
-        $interface = $schema->getInterface(Inheritance::modelToInterface($c2a));
+        $interface = $schema->getInterface(Inheritance::interfaceName($c2a->getName()));
         $this->assertNull($interface);
         $this->assertInterfaces(['DataObjectInterface', 'C2Interface', 'CInterface'], $c2a);
 
         $c2 = $schema->getModelByClassName(C2::class);
         $this->assertNotNull($c2);
-        $interface = $schema->getInterface(Inheritance::modelToInterface($c2));
+        $interface = $schema->getInterface(Inheritance::interfaceName($c2->getName()));
         $this->assertFields(['C2Field'], $interface);
         $this->assertInterfaces(['DataObjectInterface', 'C2Interface', 'CInterface'], $c2);
     }

--- a/tests/Schema/DataObject/TestSchema.php
+++ b/tests/Schema/DataObject/TestSchema.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
+
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\GraphQL\Schema\DataObject\ModelCreator;
+use SilverStripe\GraphQL\Schema\DataObject\ReadCreator;
+use SilverStripe\GraphQL\Schema\Schema;
+use SilverStripe\GraphQL\Schema\SchemaConfig;
+
+class TestSchema extends Schema implements TestOnly
+{
+    public function __construct($key = 'test')
+    {
+        parent::__construct($key, new SchemaConfig([
+            'modelCreators' => [ ModelCreator::class ],
+            'modelConfig' => [
+                'DataObject' => [
+                    'base_fields' => ['ID' => 'ID'],
+                    'operations' => [
+                        'read' => [
+                            'class' => ReadCreator::class,
+                        ],
+                    ],
+                ],
+            ]
+        ]));
+    }
+}

--- a/tests/Schema/DataObject/TestSchema.php
+++ b/tests/Schema/DataObject/TestSchema.php
@@ -3,7 +3,6 @@
 
 namespace SilverStripe\GraphQL\Tests\Schema\DataObject;
 
-
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\GraphQL\Schema\DataObject\ModelCreator;
 use SilverStripe\GraphQL\Schema\DataObject\ReadCreator;

--- a/tests/Schema/IntegrationTest.php
+++ b/tests/Schema/IntegrationTest.php
@@ -174,11 +174,6 @@ GRAPHQL;
         $this->assertSchemaNotHasType($schema, 'FakePageVersion');
     }
 
-    public function testInheritance()
-    {
-        $this->markTestSkipped();
-    }
-
     public function testPluginOverride()
     {
         $schema = $this->createSchema(new TestSchemaBuilder(['_' . __FUNCTION__]));
@@ -198,11 +193,15 @@ GRAPHQL;
 query {
   readFakePages {
     nodes {
-        title
+        ... on FakePageInterface {
+            title
+        }
     }
     edges {
         node {
-            title
+            ... on FakePageInterface {
+                title
+            }
         }
     }
   }
@@ -265,7 +264,7 @@ GRAPHQL;
         $query = <<<GRAPHQL
 query {
   readOneDataObjectFake {
-    id
+    myInt
     myField
   }
 }
@@ -278,7 +277,7 @@ GRAPHQL;
             'models' => [
                 DataObjectFake::class => [
                     'fields' => [
-                        'id' => false,
+                        'myInt' => false,
                         'myField' => true,
                     ],
                     'operations' => [
@@ -290,7 +289,7 @@ GRAPHQL;
         $schema = $this->createSchema($factory);
         $result = $this->querySchema($schema, $query);
         $this->assertFailure($result);
-        $this->assertMissingField($result, 'id');
+        $this->assertMissingField($result, 'myInt');
 
         $factory = new TestSchemaBuilder();
         $factory->extraConfig = [
@@ -371,7 +370,9 @@ query {
       firstName
     }
     files {
-      id
+      ... on FileInterface {
+        id
+      }
     }
   }
 }

--- a/tests/Schema/IntegrationTest.php
+++ b/tests/Schema/IntegrationTest.php
@@ -9,7 +9,7 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\QueryHandler\QueryHandler;
-use SilverStripe\GraphQL\QueryHandler\SchemaContextProvider;
+use SilverStripe\GraphQL\QueryHandler\SchemaConfigProvider;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Exception\SchemaNotFoundException;
 use SilverStripe\GraphQL\Schema\Field\Query;
@@ -1021,7 +1021,7 @@ GRAPHQL;
         $graphQLSchena = $builder->fetchSchema($schema);
         $handler = new QueryHandler();
         $schemaContext = $builder->getConfig($schema->getSchemaKey());
-        $handler->addContextProvider(SchemaContextProvider::create($schemaContext));
+        $handler->addContextProvider(SchemaConfigProvider::create($schemaContext));
         try {
             return $handler->query($graphQLSchena, $query, $variables);
         } catch (Exception $e) {

--- a/tests/Schema/_testFieldInclusion/models.yml
+++ b/tests/Schema/_testFieldInclusion/models.yml
@@ -1,5 +1,6 @@
 SilverStripe\GraphQL\Tests\Fake\DataObjectFake:
   fields:
     myField: true
+    myInt: true
   operations:
     readOne: true

--- a/tests/Schema/_testModelPlugins/models.yml
+++ b/tests/Schema/_testModelPlugins/models.yml
@@ -2,3 +2,5 @@ SilverStripe\GraphQL\Tests\Fake\DataObjectFake:
   fields: '*'
 SilverStripe\GraphQL\Tests\Fake\FakeSiteTree:
   fields: '*'
+SilverStripe\GraphQL\Tests\Fake\FakePage:
+  fields: '*'


### PR DESCRIPTION
## Overview

This pull request does away with the idiosyncratic and verbose `_extends` field we used to navigate the inheritance pattern of ORM-generated types and instead leverage some of the native abstractions provided by the GraphQL spec that are better suited for this purpose.

Relevant: https://github.com/silverstripe/silverstripe-graphql/issues/209

Docs: https://github.com/silverstripe/silverstripe-framework/pull/9912

## To be merged after
* [ ] https://github.com/silverstripe/silverstripe-asset-admin/pull/1201
* [ ] https://github.com/silverstripe/silverstripe-versioned/pull/331
* [ ] https://github.com/silverstripe/silverstripe-framework/pull/9912


Tests:

* Unit tests passing
* Doesn't break elemental
* Doesn't break asset admin

There are several components to this revision.

## Part 1: Inherited fields / implicit exposures

* Exposing a type implicitly exposes all of its **ancestors**.
* Ancestors receive any fields exposed by their descendants, if applicable.
* Exposing a type applies all of its fields to descendants **only if they are explicitly exposed also**. 

Serviced by: `SilverStripe\GraphQL\Schema\DataObject\InheritanceBuilder`

### Example:

```yaml
BlogPage:
  fields: 
    title: true
    content: true
    date: true
GalleryPage:
  fields:
    images: true
    urlSegment: true
```

This results in these two types being exposed with the fields as shown, but also results in a `Page` type:

```
type Page {
  id: ID! # always exposed
  title: String
  content: String
  urlSegment: String
}
```

## Part 2: Interfaces

Any type that's part of an inheritance chain will generate interfaces. Each applicable ancestral interface is added to the type. Like the type inheritance pattern shown above, interfaces duplicate fields from their ancestors as well.

Additionally, a **base interface** is provided for all types containing common fields across the entire DataObject schema.

Serviced by: `SilverStripe\GraphQL\Schema\DataObject\InterfaceBuilder`

### Example

```
Page:
  BlogPage extends Page
  EventsPage extends Page
    ConferencePage extends EventsPage
    WebinarPage extends EventsPage
```

This will create the following interfaces:

```
interface PageInterface {
  title: String
  content: String
}

interface BlogPageInterface {
  id: ID!
  title: String
  content: String
  date: String
}

interface EventsPageInterface {
  id: ID!
  title: String
  content: String
  numberOfTickets: Int
}

interface ConferencePageInterface {
  id: ID!
  title: String
  content: String
  numberOfTickets: Int
  venueAddress: String
}

interface WebinarPageInterface {
  id: ID!
  title: String
  content: String
  numberOfTickets: Int
  zoomLink: String
}
```

Types then get these interfaces applied, like so:

```
type Page implements PageInterface {}
type BlogPage implements BlogPageInterface & PageInterface {}
type EventsPage implements EventsPageInterface & PageInterface {} 
type ConferencePage implements ConferencePageInterface & EventsPageInterface & PageInterface {} 
type WebinarPage implements WebinarPageInterface & EventsPageInterface & PageInterface {} 
```

Lastly, for good measure, we create a `DataObjectInterface` that applies to everything.

```
interface DataObjectInterface {
  id: ID!
  # Any other fields you've explicitly exposed in config.modelConfig.DataObject.base_fields
}
```

```
type Page implements PageInterface & DataObjectInterface {}
```

## Part 3: Unions and Union Queries

Models that have descendants will create unions that include themselves and all of their descendants. For queries that return those models, a union is put in its place.

Serviced by: `SilverStripe\GraphQL\Schema\DataObject\InheritanceUnionBuilder`

### Example

```
type Page implements PageInterface {}
type BlogPage implements BlogPageInterface & PageInterface {}
type EventsPage implements EventsPageInterface & PageInterface {} 
type ConferencePage implements ConferencePageInterface & EventsPageInterface & PageInterface {} 
type WebinarPage implements WebinarPageInterface & EventsPageInterface & PageInterface {} 
```

Creates the following unions:

```
union PageInheritanceUnion = Page | BlogPage | EventsPage | ConferencePage | WebinarPage
union EventsPageInheritanceUnion = EventsPage | ConferencePage | WebinarPage
```

"Leaf" models like `BlogPage`, `ConferencePage`, and `WebinarPage` that have no exposed descendants will not create unions, as they are functionally useless.

This means that queries for `readPages` and `readEventsPages` will now return unions.

```graphql
readPages {
  nodes {
    ... on BlogPage {
      date
    }
    ... on WebinarPage {
      zoomLink
    }
  }
}
```

This works fine for leaf models, but what if we want the `title` field? One option is to add it to each `... on` clause, as we know its been propagated down through the inheritance builder in part 1, above. But a better way to do this is to leverage the common interface.

```graphql
query {
  readPages {
    nodes {
      ... on PageInterface {
        id # in theory, this common field could be done on DataObjectInterface, but that gets a bit verbose
        title
        content
      }
      ... on EventsPageInterface {
        numberOfTickets
      }
      ... on BlogPage {
        date
      }
      ... on WebinarPage {
        zoomLink
      }
    }
  }
}
```

A good way of negotiating whether to use interfaces or types in the `... on` block is to ask the question "Could this field appear on more than one type?" If the answer is yes, you want an interface.

### Elemental

One of the primary motivators for this refactor was the awkwardness of querying for content blocks. Almost by definition, content blocks are always abstractions. You're never going to query for a `BaseElement` type specifically. You're always asking for an assortment of its descendants, which adds a lot of polymorphism to the query.

```graphql
query {
  readElementalPages {
    nodes {
      elementalArea {
        elements {
          nodes {
            ... on BaseElementInterface {
              title
              id
            }
            ... on ContentBlock {
              html
            }
            ... on CTABlock {
              link
              linkText
            }
          }
        }
      }
    }
  }
}
```
## To consider

This has the undesirable effect of breaking GraphQL APIs when a subclass is added. We've always thought of this as having dangerous consequences for the use of GraphQL in the CMS, but now that we're using a build step to generate the schema, it's conceivable that we could mitigate that problem at build time with static query generation for CMS consumption.

For users consuming GraphQL in their own app code, this does indeed break their APIs, and we should make sure they're aware of it. There are an increasing number of these "heads up" cases that we want to include in the build script, and I'm proposing a `SchemaAuditInterface` API, where you could add your own set of auditors that would compare the previous schema to the next one and throw warnings or fatals when something isn't right.

A simple auditor that checks if any query has changed its return type would make a great auditor to start with.

## Also in this PR

* `className` allowed by default for DataObject types
* New `base_fields` setting for fields that are *required* to be exposed on each model
* `SchemaContextProvider` is now more appropriately named `SchemaConfigProvider`
* Allow query to be pre-parsed in `QueryHandlerInterface`
* Fire events for graphqlQuery, graphqlMutation
* New `QueryStateProvider` for exposing shared query state to resolvers
* JSONBlob is now natively supported (bespoke scalar for elemental now deprecated)