### PR TITLE
API Block older version module from using this minor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,12 @@
         "silverstripe/vendor-plugin": "^1.0",
         "webonyx/graphql-php": "~0.12.6"
     },
+    "conflict": {
+        "silverstripe/admin": "<1.8",
+        "silverstripe/versioned": "<1.8",
+        "silverstripe/asset-admin": "<1.8",
+        "dnadesign/silverstripe-elemental": "<4.6"
+    },
     "require-dev": {
         "sminnee/phpunit": "^5.7",
         "sminnee/phpunit-mock-objects": "^3.4.5",


### PR DESCRIPTION
Version 3.5 of GraphQL expects different cases for some queries. Older version of modules that depend on this module will not work with 3.5.

This PR aims to make this conflict explicit.

# Parent issue
- https://github.com/silverstripeltd/product-issues/issues/416
