### PR TITLE
NEW Add TestSessionEnvironmentExtension to support behat tests

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -42,3 +42,10 @@ Only:
 SilverStripe\Admin\LeftAndMain:
   extensions:
     - SilverStripe\GraphQL\Extensions\ClientConfigProvider
+---
+Only:
+  moduleexists: 'silverstripe/testsession'
+---
+SilverStripe\TestSession\TestSessionEnvironment:
+  extensions:
+    - SilverStripe\GraphQL\Extensions\TestSessionEnvironmentExtension

--- a/src/Extensions/TestSessionEnvironmentExtension.php
+++ b/src/Extensions/TestSessionEnvironmentExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SilverStripe\GraphQL\Extensions;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\GraphQL\Schema\Schema;
+use SilverStripe\GraphQL\Schema\SchemaBuilder;
+use SilverStripe\GraphQL\Schema\Exception\EmptySchemaException;
+use SilverStripe\GraphQL\Dev\Benchmark;
+
+class TestSessionEnvironmentExtension extends Extension
+{
+    /**
+     * Build the graphql schema after a new testsession is started
+     * This is to ensure that the schema is available when a behat test is run, particularly on CI
+     * This does laregely the same thing as SilverStripe\GraphQL\Dev\Build::buildSchema(), though
+     * it also checks for the existance of persisted schemas first do that the schema is not rebuilt
+     * after each behat scenario
+     */
+    public function onAfterStartTestSession()
+    {
+        Schema::setVerbose(true);
+        $keys = array_keys(Schema::config()->get('schemas'));
+        $keys = array_filter($keys, function ($key) {
+            return $key !== Schema::ALL;
+        });
+        $builder = SchemaBuilder::singleton();
+        foreach ($keys as $key) {
+            // skip if the schema has already been built and persisted in the filesystem
+            if ($builder->getSchema($key)) {
+                continue;
+            }
+            Benchmark::start('build-schema-' . $key);
+            $schema = $builder->boot($key);
+            try {
+                $builder->build($schema);
+            } catch (EmptySchemaException $e) {
+                Schema::message('Schema ' . $key . ' is empty. Skipping.');
+            }
+            Schema::message(
+                Benchmark::end('build-schema-' . $key, 'Built schema in %sms.')
+            );
+        }
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-campaign-admin/issues/192

Related issue https://github.com/silverstripe/silverstripe-asset-admin/issues/1186

The travis config on graphql 4 isn't actually running a behat test, so I also created a one off test with cut down travis file where behat is not an allowable failure: https://travis-ci.com/github/silverstripe/silverstripe-graphql/builds/225807605 - the code state for this test was https://github.com/silverstripe/silverstripe-graphql/pull/380/commits/76bbd3f11217f638af0e0c04ef7208bdd5f8085c.  

The assumption is that fixing the asset-admin behat test will also fix the campaign-admin test that is the parent issue of this pr