### PR TITLE
Use public/_graphql/ subfolder

### DIFF
--- a/src/Schema/Services/SchemaTranscriber.php
+++ b/src/Schema/Services/SchemaTranscriber.php
@@ -47,16 +47,18 @@ class SchemaTranscriber
 
     /**
      * SchemaTranscriber constructor.
+     *
      * @param GraphQLSchema $schema
      * @param string $name
-     * @param string $rootDir
+     * @param string $rootDir Storage path for the generated file.
+     *                        Caution: This location may be used by frontend assets relying on GraphQL, e.g. silverstripe/assets.
      */
-    public function __construct(GraphQLSchema $schema, string $name, string $rootDir = PUBLIC_PATH)
+    public function __construct(GraphQLSchema $schema, string $name, string $rootDir = null)
     {
         $this->fs = new Filesystem();
         $this->schema = $schema;
         $this->name = $name;
-        $this->rootDir = $rootDir;
+        $this->rootDir = $rootDir ?: Path::join(PUBLIC_PATH, '_graphql');
     }
 
     /**


### PR DESCRIPTION
This is consistent with public/_resources which is also auto-generated by the CMS.
It enables sysadmins to lock down write access to public/ during runtime, with this potentially granular exception.
And it makes it easier to discover which part of the system is responsible for writing these files.

The change is backwards compatible with existing file locations,
although we probably want to remove that before going stable:
https://github.com/silverstripe/silverstripe-graphql/issues/384

Relies on equivalent PR to silverstripe/admin at https://github.com/silverstripe/silverstripe-admin/pull/1222

The docs are already stating this new location so this was more of an oversight:
https://docs.silverstripe.org/en/4/developer_guides/graphql/getting_started/building_the_schema/#viewing-the-generated-code