### PR TITLE
NEW Require composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "silverstripe/framework": "^4",
         "silverstripe/vendor-plugin": "^1.0",
         "webonyx/graphql-php": "^14.0",
-        "silverstripe/event-dispatcher": "^0.1.2"
+        "silverstripe/event-dispatcher": "^0.1.2",
+        "silverstripe/graphql-composer-plugin": "^0.1"
     },
     "require-dev": {
         "sminnee/phpunit": "^5.7",


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-graphql-composer-plugin

This is preparing to add GraphQL v4 to CMS 4.9 by default,
at which point everyone will need to generate GraphQL code one way or another.

Context:
1. GraphQL v4 requires generated code to function
2. The code is generated via explicit commands or implicitly via fallbacks
3. Since that code is persisted as files, fallbacks aren't suitable for multi server environments. The generated code *needs* to be in place before the codebase is deployed

There are various ways in which the code can be generated:
- Preferred: sake dev/graphql/build
- Fallback 1: dev/build
- Fallback 2: "auto build" on GraphQL request execution

This introduces a new default way: composer plugins running as part of "composer install" and "composer update".
Everyone needs to run this as part of their deployment process anyway,
unlike sake dev/graphql/build which would be a new addition.

This has the added benefit of avoiding any changes to Silverstripe Ltd platforms,
and most other people's deployment routines - it's doing the right thing by default.
If you are deploying archives, SCP'ing or even FTP'ing,
as long as you base this on a directory/file denylist (rather than allowlist),
the new .graphql/ and public/*.types.graphql files will be included.

And if you have a really weird deployment setup,
you can either choose to check in those files in the repo,
or rely on the dev/build and "auto build" fallbacks as a last resort.

The tradeoff here is that there's more noise and unexpected output
in every "composer install" and "composer update". Aaron and me considered
only showing "building schemas" as a single line output, but that wouldn't
make it clear that the same activity happens on "sake dev/graphql/build".
It also makes those composer commands marginally slower (3-20s).
Which is why the module allows disabling this behaviour via an env var.