### PR TITLE
API New $class arg for DataObjectModel->getModelTypeForField()

### DIFF
--- a/src/Schema/DataObject/DataObjectModel.php
+++ b/src/Schema/DataObject/DataObjectModel.php
@@ -311,13 +311,18 @@ class DataObjectModel implements
      * get that field.
      *
      * @param string $fieldName
+     * @param string $class Optional class name for model fields which would result in database queries.
+     *                      The database is not always available when the schema is built (e.g. on deployment servers).
      * @return ModelType|null
      * @throws SchemaBuilderException
      */
-    public function getModelTypeForField(string $fieldName): ?ModelType
+    public function getModelTypeForField(string $fieldName, $class = null): ?ModelType
     {
-        $result = $this->getFieldAccessor()->accessField($this->dataObject, $fieldName);
-        $class = $this->getModelClass($result);
+        if (!$class) {
+            $result = $this->getFieldAccessor()->accessField($this->dataObject, $fieldName);
+            $class = $this->getModelClass($result);
+        }
+
         if (!$class) {
             return null;
         }

--- a/src/Schema/Field/Field.php
+++ b/src/Schema/Field/Field.php
@@ -171,6 +171,7 @@ class Field implements
             'description',
             'resolver',
             'resolverContext',
+            'resolvedModelClass',
             'plugins',
         ]);
 

--- a/src/Schema/Field/ModelField.php
+++ b/src/Schema/Field/ModelField.php
@@ -23,6 +23,11 @@ class ModelField extends Field
     private $modelTypeFields = null;
 
     /**
+     * @var string|null
+     */
+    private $resolvedModelClass = null;
+
+    /**
      * @var string
      */
     private $property;
@@ -31,7 +36,7 @@ class ModelField extends Field
      * ModelField constructor.
      * @param string $name
      * @param $config
-     * @param SchemaModelInterface $model
+     * @param SchemaModelInterface $model The model containing this field (different from the model this field might resolve to)
      * @throws SchemaBuilderException
      */
     public function __construct(string $name, $config, SchemaModelInterface $model)
@@ -71,6 +76,10 @@ class ModelField extends Field
             $this->setResolver($this->getModel()->getDefaultResolver($this->getResolverContext()));
         }
 
+        if (isset($config['resolvedModelClass'])) {
+            $this->resolvedModelClass = $config['resolvedModelClass'];
+        }
+
         $this->modelTypeFields = $config['fields'] ?? null;
 
         unset($config['fields']);
@@ -98,7 +107,8 @@ class ModelField extends Field
         if (Schema::isInternalType($type)) {
             return null;
         }
-        $model = $this->getModel()->getModelTypeForField($this->getName());
+
+        $model = $this->getModel()->getModelTypeForField($this->getName(), $this->resolvedModelClass);
         if ($model) {
             $config = [];
             if ($this->modelTypeFields) {


### PR DESCRIPTION
Avoids calling `accessField()` which in turn calls `DataObject->obj()`. It isn't directly interested in the actual return value, but rather the *type* of this return value. Due to the way the ORM and DataObject is built, we can't guarantee lazy evaluation of those return values. Some of them cause database queries. One example here is `Versioned->versions()`, which performs in-memory operations on a (lazy) `DataList` that turn it into a (concrete) `ArrayList`.

Performing database queries slows down schema generation, but more importantly the database might not be available when we build the schema as part of a deployment operation (rather than a dev or production environment). For example, when creating a deployment package on CircleCI which then gets transferred to the actual production environment.

Context: https://github.com/silverstripe/silverstripe-graphql/issues/388