### PR TITLE
BUGFIX: Replace graceful failure of field access on dataobjects

### DIFF
--- a/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
+++ b/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
@@ -665,13 +665,11 @@ class DataObjectScaffolder implements ManagerMutatorInterface, ScaffolderInterfa
         }
 
         $resolver = function ($obj, $args, $context, $info) {
-            /* @var DataObject $obj */
-            try {
-                $field = StaticSchema::inst()->accessField($obj, $info->fieldName);
-            } catch (InvalidArgumentException $e) {
-                // Gracefully fail when field doesn't exist
+            $accessor = StaticSchema::inst()->getFieldAccessor();
+            if (!$accessor || !$accessor->getObjectFieldName($obj, $info->fieldName)) {
                 return null;
             }
+            $field = StaticSchema::inst()->accessField($obj, $info->fieldName);
             // return the raw field value, or checks like `is_numeric()` fail
             if ($field instanceof DBField && $field->isInternalGraphQLType()) {
                 return $field->getValue();

--- a/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
+++ b/src/Scaffolding/Scaffolders/DataObjectScaffolder.php
@@ -665,10 +665,13 @@ class DataObjectScaffolder implements ManagerMutatorInterface, ScaffolderInterfa
         }
 
         $resolver = function ($obj, $args, $context, $info) {
-            /**
-             * @var DataObject $obj
-             */
-            $field = StaticSchema::inst()->accessField($obj, $info->fieldName);
+            /* @var DataObject $obj */
+            try {
+                $field = StaticSchema::inst()->accessField($obj, $info->fieldName);
+            } catch (InvalidArgumentException $e) {
+                // Gracefully fail when field doesn't exist
+                return null;
+            }
             // return the raw field value, or checks like `is_numeric()` fail
             if ($field instanceof DBField && $field->isInternalGraphQLType()) {
                 return $field->getValue();


### PR DESCRIPTION
This is a tricky one with a lot of approaches for a fix, but this is the only way that doesn't break any APIs.

## The issue

`versioned-snapshot-admin` is broken because it queries for fields like `absoluteLink` and `version` on the origin record of all snapshots. Sometimes, these origins don't have those fields. The most common case is "SnapshotEvent", which is basically an arbitrary point in time -- "imported translations", e.g. , and these fields don't exist.

In < 3.5, this failed gracefully, because [the accessor](https://github.com/silverstripe/silverstripe-graphql/blob/3.4/src/Scaffolding/Scaffolders/DataObjectScaffolder.php#L672) was a simple `$obj->obj($fieldName)`. In 3.5, we've introduced the `FieldAccessor` service as a new layer of abstraction. The service we use (for graphql 4 compat) is `CaseInsensitiveFieldAccessor` . This implementation [throws when a field is not found](https://github.com/silverstripe/silverstripe-graphql/blob/3.5/src/Util/CaseInsensitiveFieldAccessor.php#L53).

This is a regression. Missing fields used to fail gracefully. Now they throw.

### Option A
Remove exception from `CaseInsensitiveFieldAccessor` (API change)

### Option B
Add option to suppress errors to `CaseInsensitiveFieldAccessor` (complicated, and probably an API change if it's enabled by default)

### Option C
Update `SnapshotEvent` to include stubs for `AbsoluteLink`, `Version`, etc., that just return null. (Coding to the implementation, not the intention)

### Option D
✅  Catch the exception and fail gracefully (Implementation-specific code, as the `FieldAccessorInterface` does not say the method should throw)

The chosen option D isn't great, but it doesn't break any APIs, should qualify for patch release as it fixes a regression, and it's extremely unlikely that anyone would be using a custom `FieldAccessorInterface` abstraction.

## Criticality

It's blocking upgrades to 4.8. We need this fix to be in a 3.5.x patch release.