### PR TITLE
Fix type error in Controller::validateOrigin

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -274,11 +274,11 @@ class Controller extends BaseController
     /**
      * Validate an origin matches a set of allowed origins
      *
-     * @param string $origin Origin string
+     * @param string|null $origin Origin string
      * @param array $allowedOrigins List of allowed origins
      * @return bool
      */
-    protected function validateOrigin(string $origin, array $allowedOrigins)
+    protected function validateOrigin(?string $origin, array $allowedOrigins)
     {
         if (empty($allowedOrigins) || empty($origin)) {
             return false;


### PR DESCRIPTION
Since the [`Controller::getRequestOrigin`](https://github.com/silverstripe/silverstripe-graphql/blob/master/src/Controller.php#L323) method returns a `string` or `null`, the `validateOrigin` method should be relaxed to also accept `null`.

The alternate approach would be to call `validateOrigin` like so: 
```php
$originAuthorised = $this->validateOrigin($origin ?? '', $allowedOrigins);
```

This is to prevent errors being raised by PHP instead of returning the proper `403` response.