### PR TITLE
NEW: Support --no-database build option

### DIFF
--- a/src/Dev/Build.php
+++ b/src/Dev/Build.php
@@ -7,11 +7,13 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\DebugView;
+use SilverStripe\GraphQL\Schema\DataObject\FieldAccessor;
 use SilverStripe\GraphQL\Schema\Exception\EmptySchemaException;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Exception\SchemaNotFoundException;
 use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\GraphQL\Schema\SchemaBuilder;
+use SilverStripe\ORM\Connect\NullDatabaseException;
 
 class Build extends Controller
 {
@@ -62,11 +64,39 @@ class Build extends Controller
             Benchmark::start('build-schema-' . $key);
             Schema::message(sprintf('--- Building schema "%s" ---', $key));
             $builder = SchemaBuilder::singleton();
-            $schema = $builder->boot($key);
             try {
-                $builder->build($schema, $clear);
-            } catch (EmptySchemaException $e) {
-                Schema::message('Schema ' . $key . ' is empty. Skipping.');
+                $schema = $builder->boot($key);
+                try {
+                    $builder->build($schema, $clear);
+                } catch (EmptySchemaException $e) {
+                    Schema::message('Schema ' . $key . ' is empty. Skipping.');
+                }
+            } catch (NullDatabaseException $e) {
+                $candidate = null;
+                foreach ($e->getTrace() as $item) {
+                    $class = $item['class'] ?? null;
+                    $function = $item['function'] ?? null;
+                    // This is the only known path to a database query, so we'll offer some help here.
+                    if ($class === FieldAccessor::class && $function === 'accessField') {
+                        $candidate = $item;
+                        break;
+                    }
+                }
+                Schema::message("
+                    Your schema configuration requires access to the database. This can happen
+                    when you add fields that require type introspection (i.e. custom getters).
+                    It is recommended that you specify an explicit type when adding custom getters
+                    to your schema."
+                );
+                if ($candidate) {
+                    Schema::message(sprintf("
+                    This most likely happened when you tried to add the field '%s' to '%s'",
+                        $candidate['args'][1],
+                        get_class($candidate['args'][0])
+                    ));
+                }
+
+                throw $e;
             }
 
             Schema::message(

--- a/src/Dev/Build.php
+++ b/src/Dev/Build.php
@@ -86,10 +86,10 @@ class Build extends Controller
                     Your schema configuration requires access to the database. This can happen
                     when you add fields that require type introspection (i.e. custom getters).
                     It is recommended that you specify an explicit type when adding custom getters
-                    to your schema."
-                );
+                    to your schema.");
                 if ($candidate) {
-                    Schema::message(sprintf("
+                    Schema::message(sprintf(
+                        "
                     This most likely happened when you tried to add the field '%s' to '%s'",
                         $candidate['args'][1],
                         get_class($candidate['args'][0])

--- a/src/Schema/Type/ModelType.php
+++ b/src/Schema/Type/ModelType.php
@@ -89,7 +89,8 @@ class ModelType extends Type implements ExtraTypeProvider
             if (isset($fields[Schema::ALL])) {
                 $all = $fields[Schema::ALL];
                 unset($fields[Schema::ALL]);
-                $fields = array_merge([
+                $fields = array_merge(
+                    [
                     Schema::ALL => $all,
                     ],
                     $fields


### PR DESCRIPTION
Depends on: https://github.com/silverstripe/silverstripe-framework/pull/10016

When `--no-database` is used, e.g. `vendor/bin/sake dev/graphql/build --no-database`, throw a helpful exception explaining where the database use may be coming from.