### PR TITLE
Implement support for query batching (closes #177)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "silverstripe/framework": "^4.10",
         "silverstripe/vendor-plugin": "^1.0",
         "webonyx/graphql-php": "^14.0",
-        "silverstripe/event-dispatcher": "^0.1.2"
+        "silverstripe/event-dispatcher": "^0.1.2",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
See #177

This adds support for query batching using [Apollo’s `BatchHttpLink`](https://www.apollographql.com/docs/react/api/link/apollo-link-batch-http/), while preserving support for regular, non-batched queries and persisted queries. I’m not sure if it’s possible to support _both_ batched and persisted queries in the one request, I can’t find anything in the docs to suggest that it is.