### PR TITLE
BUG Always nuke cache when manually rebuilding schema

### DIFF
--- a/src/Dev/Build.php
+++ b/src/Dev/Build.php
@@ -41,7 +41,7 @@ class Build extends Controller
             echo $renderer->renderInfo("GraphQL Schema Builder", Director::absoluteBaseURL());
             echo "<div class=\"build\">";
         }
-        $clear = (bool) $request->getVar('clear');
+        $clear = true;
         $verbosity = strtoupper($request->getVar('verbosity') ?? 'INFO');
         $constantRef = sprintf('%s::%s', Logger::class, $verbosity);
         Schema::invariant(


### PR DESCRIPTION
There's no use case for not clearing the cache when rebuilding the schema

# Parent issue 
- [ ] https://github.com/silverstripe/silverstripe-graphql/issues/443