### PR TITLE
MNT Require a caret version of frameworktest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ import:
 
 env:
   global:
-    - REQUIRE_EXTRA="silverstripe/frameworktest:0.4.2"
+    - REQUIRE_EXTRA="silverstripe/frameworktest:^0.4.3"
     - BEHAT_SUITE="asset-admin --config vendor/silverstripe/asset-admin/behat.yml"
 
 before_script:


### PR DESCRIPTION
Need ^0.4.3 to fix guzzle issue - https://app.travis-ci.com/github/silverstripe/silverstripe-graphql/jobs/563992053#L481

Not including frameworktest in composer.json because it's running behat tests in the asset-admin module, not on the graphql module