### PR TITLE
FIX Don't override Build link in /dev

### DIFF
--- a/_config/dev.yml
+++ b/_config/dev.yml
@@ -6,7 +6,7 @@ SilverStripe\Dev\DevelopmentAdmin:
     graphql:
       controller: SilverStripe\GraphQL\Dev\DevelopmentAdmin
       links:
-        build: 'Build/rebuild the GraphQL schema'
+        graphql: 'List GraphQL development tools'
 SilverStripe\GraphQL\Dev\DevelopmentAdmin:
   registered_controllers:
     build:

--- a/src/Dev/DevelopmentAdmin.php
+++ b/src/Dev/DevelopmentAdmin.php
@@ -19,6 +19,7 @@ class DevelopmentAdmin extends Controller
     ];
 
     private static $url_handlers = [
+        '' => 'index',
         '$Action' => 'runRegisteredController',
     ];
 


### PR DESCRIPTION
The link in /dev for Build was being overridden by the graphql link. Also, /dev/graphql wasn't going to the index of `SilverStripe\GraphQL\Dev\DevelopmentAdmin`.