### PR TITLE
MNT Remote master branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,6 @@
         "lint": "vendor/bin/phpcs src/ tests/",
         "lint-clean": "vendor/bin/phpcbf src/ tests/"
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "4.x-dev"
-        }
-    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "suggest": {


### PR DESCRIPTION
[Travis builds are failing](https://app.travis-ci.com/github/silverstripe/silverstripe-graphql/builds/250144247) on composer dependency resolution - it looks like this is caused by the alias, which needs to be removed in any event.

I don't think this will actually fix the tests until it has been merged (and packagist therefore picks up on it) - it may even need to be merged up to master before it takes effect.

## Parent issue:
- https://github.com/silverstripeltd/product-issues/issues/542