### PR TITLE
ENH Store generated graphql schema in a temp directory by default [POC]

### DIFF
--- a/src/Dev/Build.php
+++ b/src/Dev/Build.php
@@ -67,11 +67,16 @@ class Build extends Controller
 
         // Check for old code dir
         if (is_dir(BASE_PATH . '/.graphql')) {
+            $dirName = CodeGenerationStore::config()->get('dirName');
+            $newDirNameMsg = $dirName
+                ? 'The new directory is named "' . $dirName . '".'
+                : 'The schema will be built inside your silverstripe-cache directory by default,
+                but we recommend setting a specific directory in '
+                . CodeGenerationStore::class . '.dirName';
             $logger->warning(
                 'You have a .graphql/ directory in your project root. This is no longer the default
-                name. The new directory is named ' . CodeGenerationStore::config()->get('dirName') . '. You may
-                want to delete this directory and update your .gitignore file, if you are ignoring the generated
-                GraphQL code.'
+                name. ' . $newDirNameMsg . ' You may want to delete this directory and update your
+                .gitignore file, if you are ignoring the generated GraphQL code.'
             );
         }
 


### PR DESCRIPTION
This is a proof of concept for storing the generated graphql schema in the `silverstripe-cache` directory.

This makes the process for migrating from graphql 3 to 4 more streamline by respecting the filesystem permissions that we have previously indicated (i.e. silverstripe only needs write access to the assets dir - _not_ the project root). For any project without its own custom schema, there should be no need to suddenly start worrying about "what is this new folder I need to add permissions for?"

Because this uses the `silverstripe-cache` directory, the schema will also be built for each system user that runs a command by default - so if the user running `sake dev/graphql/build` is different from the user running the webserver, the webserver will still end up creating a _new schema_ on demand, ignoring the one generated via sake. We could avoid this pitfall by finding a temporary directory in another way instead of relying on `TEMP_FOLDER` (e.g. checking `SS_TEMP_PATH` and falling back to `sys_get_temp_dir()`). We would need to make sure this is fine with the platform team, as they may want to ensure that directory gets blown away on deployments (like the cache directory is).

The directory is still configurable, and the wording I've chosen indicates that it's recommended to defined it. Defining the directory will mean the schema is more readily available, since it won't be blown away any time the temporary directory is cleared. We will probably want to define this by default in silverstripe/installer for new projects.

Prior to this PR, setting the directory config to a blank string would result in errors.

## Parent Issue
- https://github.com/silverstripe/silverstripe-graphql/issues/465