### PR TITLE
ENH Add .htaccess file to schema directories

### DIFF
--- a/src/Schema/Storage/CodeGenerationStore.php
+++ b/src/Schema/Storage/CodeGenerationStore.php
@@ -113,10 +113,20 @@ class CodeGenerationStore implements SchemaStorageInterface
                 $fs->mkdir($temp);
                 // Ensure none of these files get loaded into the manifest
                 $fs->touch($temp . DIRECTORY_SEPARATOR . '_manifest_exclude');
+                // Include a file to warn developers against modifying the schema manually
                 $warningFile = $temp . DIRECTORY_SEPARATOR . '__DO_NOT_MODIFY';
                 $fs->dumpFile(
                     $warningFile,
                     '*** This directory contains generated code for the GraphQL schema. Do not modify. ***'
+                );
+                // Include a file to ensure webservers don't serve the schema
+                $htaccessFile = $temp . DIRECTORY_SEPARATOR . '.htaccess';
+                $fs->dumpFile(
+                    $htaccessFile,
+                    <<<HTACCESS
+                    Require all denied
+                    RewriteRule .* - [F]
+                    HTACCESS
                 );
             } catch (IOException $e) {
                 throw new RuntimeException(sprintf(

--- a/tests/Schema/IntegrationTest.php
+++ b/tests/Schema/IntegrationTest.php
@@ -1176,6 +1176,27 @@ GRAPHQL;
         $this->assertResult('readOneDataObjectFake.id', $id1, $result);
     }
 
+    public function testHtaccess(): void
+    {
+        FakeProductPage::get()->removeAll();
+        $schema = $this->createSchema(new TestSchemaBuilder(['_testSimpleType']));
+
+        $file = Path::join(
+            __DIR__,
+            CodeGenerationStore::config()->get('dirName'),
+            $schema->getSchemaKey(),
+            '.htaccess'
+        );
+        $this->assertFileExists($file);
+        $this->assertEquals(
+            <<<HTACCESS
+            Require all denied
+            RewriteRule .* - [F]
+            HTACCESS,
+            file_get_contents($file)
+        );
+    }
+
     /**
      * @param TestSchemaBuilder $factory
      * @return Schema


### PR DESCRIPTION
Silverstripe Cloud will put the schema inside the public directory if it is declared as a shared folder in platform.yml
Declaring it as a shared folder is going to be our recommended best practice.

## Parent issue
- https://github.com/silverstripe/silverstripe-graphql/issues/452