### PR TITLE
MNT Rename test class to conform with standard naming convention (v3)

### DIFF
--- a/tests/Middleware/BaseMiddlewareProcessTest.php
+++ b/tests/Middleware/BaseMiddlewareProcessTest.php
@@ -8,7 +8,7 @@ use GraphQL\Type\Schema;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Middleware\QueryMiddleware;
 
-abstract class MiddlewareProcessTestBase extends SapphireTest
+abstract class BaseMiddlewareProcessTest extends SapphireTest
 {
     /**
      * @var callable

--- a/tests/Middleware/CSRFMiddlewareTest.php
+++ b/tests/Middleware/CSRFMiddlewareTest.php
@@ -6,7 +6,7 @@ use Exception;
 use SilverStripe\GraphQL\Middleware\CSRFMiddleware;
 use SilverStripe\Security\SecurityToken;
 
-class CSRFMiddlewareTest extends MiddlewareProcessTestBase
+class CSRFMiddlewareTest extends BaseMiddlewareProcessTest
 {
     public function testItDoesntDoAnythingIfNotAMutation()
     {

--- a/tests/Middleware/HTTPMethodMiddlewareTest.php
+++ b/tests/Middleware/HTTPMethodMiddlewareTest.php
@@ -5,7 +5,7 @@ namespace SilverStripe\GraphQL\Tests\Middleware;
 use Exception;
 use SilverStripe\GraphQL\Middleware\HTTPMethodMiddleware;
 
-class HTTPMethodMiddlewareTest extends MiddlewareProcessTestBase
+class HTTPMethodMiddlewareTest extends BaseMiddlewareProcessTest
 {
     public function testItDoesntDoAnythingIfNotAMutation()
     {


### PR DESCRIPTION
This is currently a hardcoded exception to removing tests in our travis config because the file name isn't following the convention.
Moving to github actions, we don't want to have such hardcoded exceptions.

## Parent issues
- https://github.com/silverstripe/github-actions-ci-cd/issues/36
- https://github.com/silverstripe/gha-ci/issues/4