### PR TITLE
MNT Rename test class to conform with standard naming convention (v4)

### DIFF
--- a/tests/Middleware/BaseMiddlewareProcessTest.php
+++ b/tests/Middleware/BaseMiddlewareProcessTest.php
@@ -9,7 +9,7 @@ use SilverStripe\Dev\SapphireTest;
 use SilverStripe\GraphQL\Middleware\QueryMiddleware;
 use SilverStripe\GraphQL\Schema\Schema as SchemaSchema;
 
-abstract class MiddlewareProcessTestBase extends SapphireTest
+abstract class BaseMiddlewareProcessTest extends SapphireTest
 {
     /**
      * @var callable

--- a/tests/Middleware/CSRFMiddlewareTest.php
+++ b/tests/Middleware/CSRFMiddlewareTest.php
@@ -6,7 +6,7 @@ use Exception;
 use SilverStripe\GraphQL\Middleware\CSRFMiddleware;
 use SilverStripe\Security\SecurityToken;
 
-class CSRFMiddlewareTest extends MiddlewareProcessTestBase
+class CSRFMiddlewareTest extends BaseMiddlewareProcessTest
 {
     public function testItDoesntDoAnythingIfNotAMutation()
     {


### PR DESCRIPTION
This is currently a hardcoded exception to removing tests in our travis config because the file name isn't following the convention.
Moving to github actions, we don't want to have such hardcoded exceptions.

## Parent issues
- https://github.com/silverstripe/github-actions-ci-cd/issues/36
- https://github.com/silverstripe/gha-ci/issues/4