### PR TITLE
typecast vars to ensure the value is an array

### DIFF
--- a/src/QueryHandler/QueryHandler.php
+++ b/src/QueryHandler/QueryHandler.php
@@ -102,7 +102,7 @@ class QueryHandler implements
             return GraphQL::executeQuery($schema, $query, null, $context, $vars);
         };
 
-        return $this->callMiddleware($schema, $query, $context, (array) $vars, $last);
+        return $this->callMiddleware($schema, $query, $context, $vars ?? [], $last);
     }
 
 

--- a/src/QueryHandler/QueryHandler.php
+++ b/src/QueryHandler/QueryHandler.php
@@ -102,7 +102,7 @@ class QueryHandler implements
             return GraphQL::executeQuery($schema, $query, null, $context, $vars);
         };
 
-        return $this->callMiddleware($schema, $query, $context, $vars, $last);
+        return $this->callMiddleware($schema, $query, $context, (array) $vars, $last);
     }
 
 


### PR DESCRIPTION
The method `callMiddleware` expects the fourth parameter to be an array while in the method `queryAndReturnResult` it can be either an array or null.