### PR TITLE
MNT Require  updated frameworktest for elemental behat tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ import:
 
 env:
   global:
-    - REQUIRE_EXTRA="dnadesign/silverstripe-elemental:4.x-dev silverstripe/frameworktest:^0.4.4"
+    - REQUIRE_EXTRA="dnadesign/silverstripe-elemental:4.x-dev silverstripe/frameworktest:^0.4.5"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Fixes this broken job: https://app.travis-ci.com/github/silverstripe/silverstripe-graphql/jobs/574324004#L1976

The tests were added in https://github.com/silverstripe/silverstripe-elemental/pull/911