### PR TITLE
FIX Handle missing tables in postgres on flush

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -109,7 +109,7 @@ class Controller extends BaseController implements Flushable
                 Versioned::set_stage($stage);
             }
         }
-        
+
         // Check for a possible CORS preflight request and handle if necessary
         // Refer issue 66:  https://github.com/silverstripe/silverstripe-graphql/issues/66
         if ($request->httpMethod() === 'OPTIONS') {
@@ -524,13 +524,9 @@ class Controller extends BaseController implements Flushable
                     }
                 } catch (DatabaseException $e) {
                     // Allow failures on table doesn't exist or no database selected as we're flushing in first DB build
-                    $messageByLine = explode(PHP_EOL, $e->getMessage());
-
-                    // Get the last line
-                    $last = array_pop($messageByLine);
-
-                    if (strpos($last, 'No database selected') === false
-                        && !preg_match('/\s*(table|relation) .* does(n\'t| not) exist/i', $last)
+                    $message = $e->getMessage();
+                    if (strpos($message, 'No database selected') === false
+                        && !preg_match('/\s*(table|relation) .* does(n\'t| not) exist/i', $message)
                     ) {
                         throw $e;
                     }


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Example https://github.com/creative-commoners/silverstripe-admin/runs/7194459625?check_suite_focus=true

Fixes postgres missing table errors on flush - meaning it's OK to have a missing table when graphql runs flush.  Currently MySQL works fine with this, though the error message from postgres does not seem to be on the bottom line of the message, so this PR makes it so the whole message is scanned.

Targeting 3.7 as that's what's used by [recipe-cms 4.10](https://github.com/silverstripe/recipe-cms/blob/4.10/composer.json#L20), which is the lowest version github actions ci is targeting

Note: travis failure is due to it being unable to no longer run on anything but the latest minor version because it trys to use installer 4.11.x-dev, which is not compatible with this old version of graphql 3.7

CI run is instead done here - https://github.com/emteknetnz/silverstripe-graphql/pull/2