### PR TITLE
MNT Refactor permission check unit tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,16 @@
-<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
-
-    <testsuites>
-        <testsuite name="Default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">tests/</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/Permission/CanViewPermissionCheckerTest.yml
+++ b/tests/Permission/CanViewPermissionCheckerTest.yml
@@ -1,0 +1,15 @@
+SilverStripe\GraphQL\Tests\Fake\DataObjectFake:
+  fake1:
+    MyInt: 1
+  fake2:
+    MyInt: 2
+
+SilverStripe\GraphQL\Tests\Fake\RestrictedDataObjectFake:
+  fake3:
+    MyInt: 3
+  fake4:
+    MyInt: 4
+  fake5:
+    MyInt: 5
+  fake6:
+    MyInt: 6


### PR DESCRIPTION
Follow up from https://github.com/silverstripe/silverstripe-graphql/pull/486

Refactored test class to be clearer what is being tested. It was failing previously because there were incorrect assumptions about the order in which objects were being written/read from the db which were very opaque.

Also updated the phpunit config via `phpunit --migrate-configuration`

This should also fix https://github.com/silverstripe/recipe-cms/runs/7352643198?check_suite_focus=true which is only failing the graphql unit test

## Parent:
- https://github.com/silverstripe/gha-ci/issues/37