### PR TITLE
MNT Backport FakeResolveInfo

### DIFF
--- a/tests/Fake/FakeResolveInfo.php
+++ b/tests/Fake/FakeResolveInfo.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SilverStripe\GraphQL\Tests\Fake;
+
+use GraphQL\Type\Definition\FieldDefinition;
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use SilverStripe\Dev\TestOnly;
+
+class FakeResolveInfo extends ResolveInfo implements TestOnly
+{
+    public function __construct(array $options = [])
+    {
+        // This is a minimal implementation that's just good enough
+        // to get unit tests to pass
+        $name = 'fake';
+        $type = Type::string();
+        foreach ($options as $key => $value) {
+            if ($key === 'name') {
+                $name = $value;
+            }
+            if ($key === 'type') {
+                if ($value === 'int') {
+                    $type = Type::int();
+                }
+            }
+        }
+        parent::__construct(
+            FieldDefinition::create(['name' => $name, 'type' => $type]),
+            [],
+            new ObjectType(['name' => 'abc', 'fields' => [$name => $type]]),
+            [],
+            new Schema([]),
+            [],
+            '',
+            null,
+            []
+        );
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fix for https://github.com/silverstripe/recipe-content-blocks/runs/7440641087?check_suite_focus=true

FakeResolveInfo was added in graphql 3.8, though it's needed in the 2.10 recipe-content-blocks test which is locked to graphql 3.7

It's a TestOnly class so no semver issues here