### PR TITLE
MNT Handle early versions of webonyx/graphql-php

### DIFF
--- a/tests/Fake/FakeResolveInfo.php
+++ b/tests/Fake/FakeResolveInfo.php
@@ -13,6 +13,11 @@ class FakeResolveInfo extends ResolveInfo implements TestOnly
 {
     public function __construct(array $options = [])
     {
+        // webonyx/graphql-php v0.12
+        if (!property_exists(__CLASS__, 'fieldDefinition')) {
+            return;
+        }
+        // webonyx/graphql-php v14
         // This is a minimal implementation that's just good enough
         // to get unit tests to pass
         $name = 'fake';


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Blocked by https://github.com/silverstripe/silverstripe-asset-admin/pull/1281

Fix https://github.com/silverstripe/recipe-content-blocks/runs/7457942258?check_suite_focus=true#step:12:67
`1) DNADesign\Elemental\Tests\Legacy\GraphQL\AddElementToAreaMutationTest::testAddingBlocksInOrder
TypeError: Argument 1 passed to GraphQL\Type\Definition\ResolveInfo::__construct() must be of the type array, object given, called in /home/runner/work/recipe-content-blocks/recipe-content-blocks/vendor/silverstripe/graphql/tests/Fake/FakeResolveInfo.php on line 39`

webonyx/graphql v0.12.6 is used on [3.7](https://github.com/silverstripe/silverstripe-graphql/blob/3.7/composer.json#L9) of graphql, v14 is used in [3.8](https://github.com/silverstripe/silverstripe-graphql/blob/3.8/composer.json#L9)

Copying what is done here - https://github.com/silverstripe/silverstripe-elemental/blob/4.9/tests/GraphQL/FakeResolveInfo.php#L15