### PR TITLE
FIX prevent installation with incompatible modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,11 @@
         "dnadesign/silverstripe-elemental": "^4.9",
         "silverstripe/frameworktest": "^0.4.4"
     },
+    "conflict": {
+        "dnadesign/silverstripe-elemental": "<4.6.0",
+        "silverstripe/admin": "<1.8.0",
+        "silverstripe/asset-admin": "<1.8.0"
+    },
     "autoload": {
         "psr-4": {
             "SilverStripe\\GraphQL\\": "src/",


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/580

Disallow installation with module versions that use graphql but lack graphql 4 support

Fixes https://github.com/dnadesign/silverstripe-elemental-userforms/runs/7625878071?check_suite_focus=true where elemental 4.0.0 is installed
