### PR TITLE
MNT Require elemental ^5 for dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
     with:
       extra_jobs: |
-        - php: 7.4
+        - php: 8.1
           endtoend: true
           endtoend_suite: asset-admin
           endtoend_config: vendor/silverstripe/asset-admin/behat.yml
-        - php: 8.0
+        - php: 8.1
           endtoend: true
           endtoend_suite: versioned-admin
           endtoend_config: vendor/silverstripe/versioned-admin/behat.yml

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "squizlabs/php_codesniffer": "^3.7",
         "silverstripe/asset-admin": "^2",
         "silverstripe/versioned-admin": "^2",
-        "dnadesign/silverstripe-elemental": "^4.9",
+        "dnadesign/silverstripe-elemental": "^5",
         "silverstripe/frameworktest": "^1"
     },
     "autoload": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10349

Fix https://github.com/silverstripe/silverstripe-graphql/runs/7757079020?check_suite_focus=true
` Problem 1
    - Root composer.json requires dnadesign/silverstripe-elemental ^4.9 -> satisfiable by dnadesign/silverstripe-elemental[4.9.0-beta1, ..., 4.x-dev].
    - dnadesign/silverstripe-elemental[4.9.0-beta1, ..., 4.x-dev] require silverstripe/framework ^4.10@dev -> found silverstripe/framework[4.10.0-beta1, ..., 4.x-dev] but it conflicts with your root composer.json require (^5).`