### PR TITLE
MNT Use branches for dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,10 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.7",
-        "silverstripe/asset-admin": "^2",
-        "silverstripe/versioned-admin": "^2",
-        "dnadesign/silverstripe-elemental": "^5",
+        "silverstripe/asset-admin": "2.x-dev",
+        "silverstripe/versioned-admin": "2.x-dev",
+        "dnadesign/silverstripe-elemental": "5.x-dev",
         "silverstripe/frameworktest": "^1"
-    },
-    "conflict": {
-        "dnadesign/silverstripe-elemental": "<4.6.0",
-        "silverstripe/admin": "<1.8.0",
-        "silverstripe/asset-admin": "<1.8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Ensures dev branches are used for CI and removes outdated unnecessary conflict rules.

## Parent issue
- https://github.com/silverstripe/silverstripe-graphql/issues/503