### PR TITLE
ENH Use HashNameObfuscator in dev environments

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -33,7 +33,7 @@ SilverStripe\Core\Injector\Injector:
       storeCreator: '%$SilverStripe\GraphQL\Schema\Interfaces\SchemaStorageCreator'
 
   SilverStripe\GraphQL\Schema\Storage\NameObfuscator:
-    class: SilverStripe\GraphQL\Schema\Storage\HybridObfuscator
+    class: SilverStripe\GraphQL\Schema\Storage\HashNameObfuscator
 
 SilverStripe\GraphQL\Schema\Schema:
   schemas: []
@@ -61,12 +61,3 @@ Only:
 SilverStripe\Core\Injector\Injector:
   SilverStripe\GraphQL\Schema\Storage\NameObfuscator:
     class: SilverStripe\GraphQL\Schema\Storage\NaiveNameObfuscator
-
----
-Name: graphqlconfig-live
-Except:
-  environment: dev
----
-SilverStripe\Core\Injector\Injector:
-  SilverStripe\GraphQL\Schema\Storage\NameObfuscator:
-    class: SilverStripe\GraphQL\Schema\Storage\HashNameObfuscator

--- a/src/Schema/Storage/HashNameObfuscator.php
+++ b/src/Schema/Storage/HashNameObfuscator.php
@@ -4,7 +4,7 @@
 namespace SilverStripe\GraphQL\Schema\Storage;
 
 /**
- * For the most obscure approach, hash the file names so they're completely undiscoverable.
+ * For the most obscure approach, hash the file names so they're highly undiscoverable in IDE search
  */
 class HashNameObfuscator implements NameObfuscator
 {

--- a/src/Schema/Storage/NameObfuscator.php
+++ b/src/Schema/Storage/NameObfuscator.php
@@ -4,7 +4,7 @@
 namespace SilverStripe\GraphQL\Schema\Storage;
 
 /**
- * Defines a service that can obfuscate classnames to make their files less discoverable
+ * Defines a service that can obfuscate classnames to make their files less discoverable in IDE Search
  */
 interface NameObfuscator
 {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-graphql/issues/500

This probably won't resolve the issue, though it does fix up issues where the .graphql-generated folder is created in a `dev` environment, commit to git and then deployed to prod.  We don't mention in [dev docs](https://docs.silverstripe.org/en/4/developer_guides/graphql/getting_started/building_the_schema/) that different obfuscation classes are used on different environments

I think there's near zero value in keeping the class name intact since it's an auto-generated class, and for debugging you can either swap out to another obfuscator (can do this in yml or by setting the DEBUG_SCHEMA env variable), or just search for the type name in file content comments e.g. `// @type:Query`.

The classname is better being more obfuscated locally for a better IDE experience IMO

Note - obfuscation was only ever intended to help the IDE experience, it's not at attempt at security https://github.com/silverstripe/silverstripe-graphql/issues/369