### PR TITLE
DEP Use webonyx/graphq-php 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,6 @@ jobs:
           endtoend: true
           endtoend_suite: silverstripe-elemental
           endtoend_config: vendor/dnadesign/silverstripe-elemental/behat.yml
+        - php: 8.2
+          phpunit: true
+#         ^^ TODO: remove this extra php 8.2 job once php 8.2 is a standard part of the gha matrix

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.1",
         "silverstripe/framework": "^5",
         "silverstripe/vendor-plugin": "^2",
-        "webonyx/graphql-php": "^14.11.8",
+        "webonyx/graphql-php": "^15.0.1",
         "silverstripe/event-dispatcher": "^1",
         "guzzlehttp/guzzle": "^7.5.0",
         "guzzlehttp/psr7": "^2.4.1",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-graphql/issues/511

I've added an extra job to PHP 8.2 in CI

Behat failure for elemental job I believe is because elemental is not yet CMS 5 compatible?  I get the same error locally running both PHP 8.1 and PHP 8.2 with the the old v14 of webonyx/graphql.

![image](https://user-images.githubusercontent.com/4809037/212231459-4cb15079-0faf-47e8-8f48-301f45e9299a.png)
