### PR TITLE
MNT Use carets for dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.7",
-        "silverstripe/asset-admin": "2.x-dev",
-        "silverstripe/versioned-admin": "2.x-dev",
-        "dnadesign/silverstripe-elemental": "5.x-dev",
+        "silverstripe/asset-admin": "^2",
+        "silverstripe/versioned-admin": "^2",
+        "dnadesign/silverstripe-elemental": "^5",
         "silverstripe/frameworktest": "^1"
     },
     "autoload": {


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/676

Fixes https://github.com/silverstripe/silverstripe-graphql/actions/runs/4130220075/jobs/7159264489#step:9:358

`Problem 1
    - silverstripe/recipe-cms 5.0.x-dev requires silverstripe/asset-admin 2.0.x-dev -> found silverstripe/asset-admin[2.0.x-dev] but it conflicts with your root composer.json require (2.x-dev).
    - silverstripe/installer 5.0.x-dev requires silverstripe/recipe-cms 5.0.x-dev -> satisfiable by silverstripe/recipe-cms[5.0.x-dev].
    - Root composer.json requires silverstripe/installer 5.0.x-dev -> satisfiable by silverstripe/installer[5.0.x-dev].`