### PR TITLE
ENH Stop using deprecated Deprecation::notification_version()

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,6 +1,0 @@
-<?php
-
-// Set to 3.0.0 to show APIs marked for removal at that version
-use SilverStripe\Dev\Deprecation;
-
-Deprecation::notification_version('4.0.0', 'silverstripe/graphql');


### PR DESCRIPTION
Backporting to release this in a patch - there's no sense releasing a new minor just for this.
Will self-merge as the change was already approved in the original PR and this has been discussed and pre-approved offline.