### PR TITLE
FIX Attempt to rebuild the schema if a schema file is missing

### DIFF
--- a/src/Schema/Storage/AbstractTypeRegistry.php
+++ b/src/Schema/Storage/AbstractTypeRegistry.php
@@ -9,6 +9,10 @@ use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ListOfType;
 use Exception;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\GraphQL\Schema\SchemaBuilder;
+use SilverStripe\GraphQL\Schema\Exception\EmptySchemaException;
+use SilverStripe\Control\Controller;
+use SilverStripe\GraphQL\Controller as GraphQLController;
 
 abstract class AbstractTypeRegistry
 {
@@ -21,7 +25,30 @@ abstract class AbstractTypeRegistry
      */
     public static function get(string $typename)
     {
-        return static::fromCache($typename);
+        try {
+            return static::fromCache($typename);
+        } catch (Exception $e) {
+            if (!Controller::has_curr() ||
+                !(Controller::curr() instanceof GraphQLController) ||
+                !Controller::curr()->autobuildEnabled()
+            ) {
+                throw $e;
+            }
+            // Try to rebuild the whole schema as fallback.
+            // This is to solve mysterious edge cases where schema files do not exist when they should.
+            // These edge cases are more likely on multi-server environments
+            $dirParts = explode(DIRECTORY_SEPARATOR, static::getSourceDirectory());
+            $key = $dirParts[count($dirParts) - 1];
+            $builder = SchemaBuilder::singleton();
+            $schema = $builder->boot($key);
+            try {
+                $builder->build($schema, true);
+            } catch (EmptySchemaException $e) {
+                // noop
+            }
+            // Attempt to return again now the schema has been rebuilt.
+            return static::fromCache($typename);
+        }
     }
 
     abstract protected static function getSourceDirectory(): string;

--- a/tests/Schema/IntegrationTest.php
+++ b/tests/Schema/IntegrationTest.php
@@ -1215,6 +1215,12 @@ GRAPHQL;
 
         $factory->build($schema, true);
 
+        // Register as the default SchemaBuilder so that any calls to
+        // SchemaBuidler::singleton() get this TestSchemaBuilder
+        // This is important for the call in AbstractTypeRegisty::get() because
+        // otherwise a duplicate .graphql-generated folder will be created
+        Injector::inst()->registerService($factory, SchemaBuilder::class);
+
         return $schema;
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-graphql/issues/500

Schema building code is copied from https://github.com/silverstripe/silverstripe-graphql/blob/4/src/Dev/Build.php#L81 though I've removed all the logging.

I did have some concerns that this may lead to make it easy to allow bad users to trigger schema rebuilds by sending graphql requests the deliberately contain things that aren't in the schema, though there appears to be validation done before it reaches that point.  For instances this is the standard graphql request send when doing a request for elemental, :

`{"operationName":"ReadBlocksForArea","variables":{"id":1},"query":"query ReadBlocksForArea($id: ID!) {\n  readOneElementalArea(filter: {id: {eq: $id}}, versioning: {mode: DRAFT}) {\n    elements {\n      id\n      title\n      blockSchema\n      obsoleteClassName\n      isLiveVersion\n      isPublished\n      version\n      canCreate\n      canPublish\n      canUnpublish\n      canDelete\n      __typename\n    }\n    __typename\n  }\n}\n"}`

I've tried adding "X"'s to various bits of this request, and tested using Firefox's "Edit and resend" in the network panel, though none of them trigger a debug break point I placed in the new code that rebuilds the schema `AbstractTypeRegistry::get()`.

These are the responses I got from the server.
- `"operationName":"XReadBlocksForAreaX"` -- standard response i.e. "ReadBlocksForArea" key isn't important
- `"XqueryX":"query ReadBlocksForArea(` -- `{ message: 'This endpoint requires a "query" parameter', code: 400, file: "/var/www/vendor/silverstripe/framework/src/Control/RequestHandler.php", … }`
- `"query":"XqueryX ReadBlocksForArea(` -- `{ message: 'Syntax Error: Unexpected Name "XqueryX"', code: 0, file: "/var/www/vendor/webonyx/graphql-php/src/Language/Parser.php", … }`
- `"query":"query XReadBlocksForAreaX(` -- standard response i.e. "ReadBlocksForArea" after query isn't important
- `XreadOneElementalAreaX(filter` -- `{ message: 'Cannot query field "XreadOneElementalAreaX" on type "Query". Did you mean "readOneElementalArea"?', code: 0, file: "/var/www/vendor/webonyx/graphql-php/src/Validator/Rules/FieldsOnCorrectType.php", … }`
- `readOneXElementalAreaX(` -- `{ message: 'Cannot query field "readOneXElementalAreaX" on type "Query". Did you mean "readOneElementalArea"?', code: 0, file: "/var/www/vendor/webonyx/graphql-php/src/Validator/Rules/FieldsOnCorrectType.php", … }`




