### PR TITLE
fix(SortPlugin): amend sorting to all fields

### DIFF
--- a/src/Schema/Plugin/SortPlugin.php
+++ b/src/Schema/Plugin/SortPlugin.php
@@ -91,9 +91,7 @@ class SortPlugin implements FieldPlugin, SchemaUpdater
                 return null;
             }
             $sortArgs = $args[$fieldName] ?? [];
-            foreach ($sortArgs as $field => $dir) {
-                $list = $list->sort($field, $dir);
-            }
+            $list = $list->sort($sortArgs);
 
             return $list;
         };

--- a/tests/Schema/IntegrationTest.php
+++ b/tests/Schema/IntegrationTest.php
@@ -425,6 +425,9 @@ GRAPHQL;
         $dataObject2 = DataObjectFake::create(['MyField' => 'test2', 'AuthorID' => $author2->ID]);
         $dataObject2->write();
 
+        $dataObject3 = DataObjectFake::create(['MyField' => 'test3', 'AuthorID' => $author2->ID]);
+        $dataObject3->write();
+
         $file1 = File::create(['Title' => 'file1']);
         $file1->write();
 
@@ -436,6 +439,7 @@ GRAPHQL;
 
         $id1 = $dataObject1->ID;
         $id2 = $dataObject2->ID;
+        $id3 = $dataObject3->ID;
 
         $schema = $this->createSchema(new TestSchemaBuilder([$dir]));
 
@@ -474,7 +478,7 @@ GRAPHQL;
 
         $query = <<<GRAPHQL
 query {
-  readOneDataObjectFake(sort: { myField: DESC }) {
+  readOneDataObjectFake(sort: { AuthorID: DESC , myField: ASC }) {
     myField
   }
 }
@@ -485,14 +489,25 @@ GRAPHQL;
 
         $query = <<<GRAPHQL
 query {
-  readOneDataObjectFake(sort: { myField: DESC }, filter: { id: { ne: $id2 } }) {
+  readOneDataObjectFake(sort: { myField: DESC }) {
     myField
   }
 }
 GRAPHQL;
         $result = $this->querySchema($schema, $query);
         $this->assertSuccess($result);
-        $this->assertResult('readOneDataObjectFake.myField', 'test1', $result);
+        $this->assertResult('readOneDataObjectFake.myField', 'test3', $result);
+
+        $query = <<<GRAPHQL
+query {
+  readOneDataObjectFake(sort: { myField: DESC }, filter: { id: { ne: $id3 } }) {
+    myField
+  }
+}
+GRAPHQL;
+        $result = $this->querySchema($schema, $query);
+        $this->assertSuccess($result);
+        $this->assertResult('readOneDataObjectFake.myField', 'test2', $result);
 
         $query = <<<GRAPHQL
 query {

--- a/tests/Schema/_testFilterAndSort/models.yml
+++ b/tests/Schema/_testFilterAndSort/models.yml
@@ -6,6 +6,7 @@ SilverStripe\GraphQL\Tests\Fake\DataObjectFake:
         sort: true
   fields:
     myField: true
+    AuthorID: true
     author:
       fields:
         firstName: true


### PR DESCRIPTION
Fix sorting to all fields in the args.

This is because in framework `DataList` each call to `->sort()` actually resets previous sorts made, and the result is that only the end sort happens.

## Issue
- fixes #542