### PR TITLE
Run dev/build add-on only once

### DIFF
--- a/_config/dataobject.yml
+++ b/_config/dataobject.yml
@@ -5,6 +5,3 @@ SilverStripe\ORM\DataObject:
   graphql_blacklisted_fields:
     LinkTracking: true
     FileTracking: true
-  extensions:
-    - SilverStripe\GraphQL\Extensions\DevBuildExtension
-

--- a/_config/dev.yml
+++ b/_config/dev.yml
@@ -1,6 +1,10 @@
 ---
 Name: graphql-dev
 ---
+SilverStripe\ORM\DatabaseAdmin:
+  extensions:
+    - SilverStripe\GraphQL\Extensions\DevBuildExtension
+
 SilverStripe\Dev\DevelopmentAdmin:
   registered_controllers:
     graphql:

--- a/src/Extensions/DevBuildExtension.php
+++ b/src/Extensions/DevBuildExtension.php
@@ -19,29 +19,25 @@ class DevBuildExtension extends DataExtension
      */
     private static bool $enabled = true;
 
-    private static bool $done = false;
-
     public function onAfterBuild(): void
     {
         if (!static::config()->get('enabled')) {
             return;
         }
-        if (!self::$done) {
-            // Get the current graphQL logger
-            $defaultLogger = Injector::inst()->get(LoggerInterface::class . '.graphql-build');
 
-            try {
-                // Define custom logger
-                $logger = Logger::singleton();
-                $logger->setVerbosity(Logger::INFO);
-                Injector::inst()->registerService($logger, LoggerInterface::class . '.graphql-build');
+        // Get the current graphQL logger
+        $defaultLogger = Injector::inst()->get(LoggerInterface::class . '.graphql-build');
 
-                Build::singleton()->buildSchema();
-                self::$done = true;
-            } finally {
-                // Restore default logger back to its starting state
-                Injector::inst()->registerService($defaultLogger, LoggerInterface::class . '.graphql-build');
-            }
+        try {
+            // Define custom logger
+            $logger = Logger::singleton();
+            $logger->setVerbosity(Logger::INFO);
+            Injector::inst()->registerService($logger, LoggerInterface::class . '.graphql-build');
+
+            Build::singleton()->buildSchema();
+        } finally {
+            // Restore default logger back to its starting state
+            Injector::inst()->registerService($defaultLogger, LoggerInterface::class . '.graphql-build');
         }
     }
 }


### PR DESCRIPTION
Instead of once for every DataObject that exists in the project. Although there's an early exist after the first execution runs, there are N-1 more runs checking the same thing. This isn't really a change, nor impactful... it is just a touch of code hygiene :)

Because, well, lol
![image](https://github.com/silverstripe/silverstripe-graphql/assets/778003/7859a869-fb3e-4aeb-a276-4f29cbb9d5ec)
