### PR TITLE
Revert "NEW Enable storing graphql schema in `silverstripe-cache/`"

### DIFF
--- a/src/Schema/Storage/CodeGenerationStore.php
+++ b/src/Schema/Storage/CodeGenerationStore.php
@@ -13,19 +13,13 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Path;
 use SilverStripe\GraphQL\Schema\Exception\EmptySchemaException;
 use SilverStripe\GraphQL\Schema\Exception\SchemaNotFoundException;
-use SilverStripe\GraphQL\Schema\Logger;
 use SilverStripe\GraphQL\Schema\Schema;
 use SilverStripe\GraphQL\Schema\SchemaConfig;
 use SilverStripe\GraphQL\Schema\StorableSchema;
-use SilverStripe\GraphQL\Schema\Type\Enum;
-use SilverStripe\GraphQL\Schema\Type\InterfaceType;
-use SilverStripe\GraphQL\Schema\Type\Type;
-use SilverStripe\GraphQL\Schema\Type\UnionType;
 use SilverStripe\GraphQL\Schema\Interfaces\SchemaStorageInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 use Psr\SimpleCache\InvalidArgumentException;
 use RuntimeException;
 
@@ -52,9 +46,6 @@ class CodeGenerationStore implements SchemaStorageInterface
     private static string $namespacePrefix = 'SSGraphQLSchema_';
 
     /**
-     * The directory, relative to $rootDir, where the generated graphql schema
-     * will be stored. If set to a blank string, generated schema will be stored
-     * in the TEMP_PATH directory.
      * @config
      */
     private static string $dirName = '.graphql-generated';
@@ -106,19 +97,38 @@ class CodeGenerationStore implements SchemaStorageInterface
         $fs = new Filesystem();
         $finder = new Finder();
         $temp = $this->getTempDirectory();
-        if ($this->dirNameIsDefined()) {
-            $dest = $this->getDirectory();
-            if ($fs->exists($dest)) {
-                $logger->info('Moving current schema to temp folder');
-                $fs->mirror($dest, $temp);
-            } else {
-                $logger->info('Creating new schema');
-                $this->createNewTempSchema($fs, $temp);
-            }
+        $dest = $this->getDirectory();
+        if ($fs->exists($dest)) {
+            $logger->info('Moving current schema to temp folder');
+            $fs->mirror($dest, $temp);
         } else {
-            $logger->info('Using temporary directory for schema');
-            $logger->info('Creating new schema which will override any old schema');
-            $this->createNewTempSchema($fs, $temp);
+            $logger->info('Creating new schema');
+            try {
+                $fs->mkdir($temp);
+                // Ensure none of these files get loaded into the manifest
+                $fs->touch($temp . DIRECTORY_SEPARATOR . '_manifest_exclude');
+                // Include a file to warn developers against modifying the schema manually
+                $warningFile = $temp . DIRECTORY_SEPARATOR . '__DO_NOT_MODIFY';
+                $fs->dumpFile(
+                    $warningFile,
+                    '*** This directory contains generated code for the GraphQL schema. Do not modify. ***'
+                );
+                // Include a file to ensure webservers don't serve the schema
+                $htaccessFile = $temp . DIRECTORY_SEPARATOR . '.htaccess';
+                $fs->dumpFile(
+                    $htaccessFile,
+                    <<<HTACCESS
+                    Require all denied
+                    RewriteRule .* - [F]
+                    HTACCESS
+                );
+            } catch (IOException $e) {
+                throw new RuntimeException(sprintf(
+                    'Could not persist schema. Failed to create directory %s. Full message: %s',
+                    $temp,
+                    $e->getMessage()
+                ));
+            }
         }
 
         $templateDir = static::getTemplateDir();
@@ -230,16 +240,15 @@ class CodeGenerationStore implements SchemaStorageInterface
         }
 
         // Move the new schema into the proper destination
-        if ($this->dirNameIsDefined()) {
-            if ($fs->exists($dest)) {
-                $logger->info('Deleting current schema');
-                $fs->remove($dest);
-            }
-            $logger->info('Migrating new schema');
-            $fs->mirror($temp, $dest);
-            $logger->info('Deleting temp schema');
-            $fs->remove($temp);
+        if ($fs->exists($dest)) {
+            $logger->info('Deleting current schema');
+            $fs->remove($dest);
         }
+
+        $logger->info('Migrating new schema');
+        $fs->mirror($temp, $dest);
+        $logger->info('Deleting temp schema');
+        $fs->remove($temp);
 
         $logger->info("Total types: $total");
         $logger->info(sprintf('Types built: %s', count($built ?? [])));
@@ -380,13 +389,9 @@ class CodeGenerationStore implements SchemaStorageInterface
 
     private function getDirectory(): string
     {
-        $dirName = $this->config()->get('dirName');
-        if (!$dirName) {
-            return $this->getTempDirectory();
-        }
         return Path::join(
             $this->getRootDir(),
-            $dirName,
+            $this->config()->get('dirName'),
             $this->name
         );
     }
@@ -394,15 +399,10 @@ class CodeGenerationStore implements SchemaStorageInterface
     private function getTempDirectory(): string
     {
         return Path::join(
-            TEMP_PATH,
-            $this->config()->get('dirName') ?: '.graphql-generated',
+            TEMP_FOLDER,
+            $this->config()->get('dirName'),
             $this->name
         );
-    }
-
-    private function dirNameIsDefined(): bool
-    {
-        return (bool) $this->config()->get('dirName');
     }
 
     private function getNamespace(): string
@@ -451,35 +451,5 @@ class CodeGenerationStore implements SchemaStorageInterface
     {
         $code = preg_replace("/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/", "\n", $rawCode ?? '');
         return "<?php\n\n /** GENERATED CODE -- DO NOT MODIFY **/\n\n{$code}";
-    }
-
-    private function createNewTempSchema(FileSystem $fs, string $tempDir): void
-    {
-        try {
-            $fs->mkdir($tempDir);
-            // Ensure none of these files get loaded into the manifest
-            $fs->touch(Path::join($tempDir, '_manifest_exclude'));
-            // Include a file to warn developers against modifying the schema manually
-            $warningFile = Path::join($tempDir, '__DO_NOT_MODIFY');
-            $fs->dumpFile(
-                $warningFile,
-                '*** This directory contains generated code for the GraphQL schema. Do not modify. ***'
-            );
-            // Include a file to ensure webservers don't serve the schema
-            $htaccessFile = Path::join($tempDir, '.htaccess');
-            $fs->dumpFile(
-                $htaccessFile,
-                <<<HTACCESS
-                Require all denied
-                RewriteRule .* - [F]
-                HTACCESS
-            );
-        } catch (IOException $e) {
-            throw new RuntimeException(sprintf(
-                'Could not persist schema. Failed to create directory %s. Full message: %s',
-                $tempDir,
-                $e->getMessage()
-            ));
-        }
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-graphql/issues/547

This reverts commit 5b8b849e25c6bcd70ad81ef2c1f11b2f8d8317d6.

Note it's essentially keeping commit https://github.com/silverstripe/silverstripe-graphql/pull/534/commits/dccde65952abbf8d35bb06c671c4d23fe4a47b41 from https://github.com/silverstripe/silverstripe-graphql/pull/534/commits (removing the unused imports)
