### PR TITLE
FIX Handle using injected subclasses

### DIFF
--- a/tests/Fake/Inheritance/MyOrig.php
+++ b/tests/Fake/Inheritance/MyOrig.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\DataObject;
+
+class MyOrig extends DataObject implements TestOnly
+{
+    private static $db = [
+        'MyField' => 'Varchar',
+    ];
+
+    private static $table_name = 'MyOrig_test';
+}

--- a/tests/Fake/Inheritance/MySubclass.php
+++ b/tests/Fake/Inheritance/MySubclass.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Tests\Fake\Inheritance;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataList;
+
+class MySubclass extends MyOrig implements TestOnly
+{
+    private static $db = [
+        'MySubclassField' => 'Varchar',
+    ];
+
+    private static $table_name = 'MySubclass_test';
+}


### PR DESCRIPTION
Issue - https://github.com/silverstripe/silverstripe-graphql/issues/524

Original fix - https://github.com/wilr/silverstripe-graphql/commit/623bc9833039996c0c52f1a756b753730923e2b4

Without code fix, new unit test will either hang indefinately or go to 256 levels of recursion if xdebug is enabled