### PR TITLE
Revert "test(SortPlugin): add integration test for multi-sort"

### DIFF
--- a/tests/Schema/IntegrationTest.php
+++ b/tests/Schema/IntegrationTest.php
@@ -425,9 +425,6 @@ GRAPHQL;
         $dataObject2 = DataObjectFake::create(['MyField' => 'test2', 'AuthorID' => $author2->ID]);
         $dataObject2->write();
 
-        $dataObject3 = DataObjectFake::create(['MyField' => 'test3', 'AuthorID' => $author2->ID]);
-        $dataObject3->write();
-
         $file1 = File::create(['Title' => 'file1']);
         $file1->write();
 
@@ -439,7 +436,6 @@ GRAPHQL;
 
         $id1 = $dataObject1->ID;
         $id2 = $dataObject2->ID;
-        $id3 = $dataObject3->ID;
 
         $schema = $this->createSchema(new TestSchemaBuilder([$dir]));
 
@@ -478,17 +474,6 @@ GRAPHQL;
 
         $query = <<<GRAPHQL
 query {
-  readOneDataObjectFake(sort: { AuthorID: DESC , myField: ASC }) {
-    myField
-  }
-}
-GRAPHQL;
-        $result = $this->querySchema($schema, $query);
-        $this->assertSuccess($result);
-        $this->assertResult('readOneDataObjectFake.myField', 'test2', $result);
-
-        $query = <<<GRAPHQL
-query {
   readOneDataObjectFake(sort: { myField: DESC }) {
     myField
   }
@@ -496,18 +481,18 @@ query {
 GRAPHQL;
         $result = $this->querySchema($schema, $query);
         $this->assertSuccess($result);
-        $this->assertResult('readOneDataObjectFake.myField', 'test3', $result);
+        $this->assertResult('readOneDataObjectFake.myField', 'test2', $result);
 
         $query = <<<GRAPHQL
 query {
-  readOneDataObjectFake(sort: { myField: DESC }, filter: { id: { ne: $id3 } }) {
+  readOneDataObjectFake(sort: { myField: DESC }, filter: { id: { ne: $id2 } }) {
     myField
   }
 }
 GRAPHQL;
         $result = $this->querySchema($schema, $query);
         $this->assertSuccess($result);
-        $this->assertResult('readOneDataObjectFake.myField', 'test2', $result);
+        $this->assertResult('readOneDataObjectFake.myField', 'test1', $result);
 
         $query = <<<GRAPHQL
 query {

--- a/tests/Schema/_testFilterAndSort/models.yml
+++ b/tests/Schema/_testFilterAndSort/models.yml
@@ -6,7 +6,6 @@ SilverStripe\GraphQL\Tests\Fake\DataObjectFake:
         sort: true
   fields:
     myField: true
-    AuthorID: true
     author:
       fields:
         firstName: true


### PR DESCRIPTION
This reverts commit 47811b88cd1ae7e39cf13ed698223f6a13b4d047.

For reasons that I do not understand, while graphql 4.3 is currently green, there are failures when running this in the context of silverstripe/installer and sink
- https://github.com/silverstripe/silverstripe-installer/actions/runs/5941845031/job/16160746239
- https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/5953679735/job/16148509886

**Do not merge unless this is green - https://github.com/emteknetnz/silverstripe-installer/actions/runs/5959183341**

`1) SilverStripe\GraphQL\Tests\Schema\DataObject\InheritanceBuilderTest::testFillAncestryInjectorSubclass
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'SilverStripe\GraphQL\Tests\Fake\Inheritance\MySubclass'
+'SilverStripe\GraphQL\Tests\Fake\Inheritance\MyOrig'`

On my local the failure was 
`1) SilverStripe\GraphQL\Tests\Schema\IntegrationTest::testFilterAndSort
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'test2'
+'test3'`

