### PR TITLE
ENH add canInit method and CAN_DEV_GRAPHQL permissions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.2",
         "silverstripe/vendor-plugin": "^2",
         "webonyx/graphql-php": "^15.0.1",
         "silverstripe/event-dispatcher": "^1",

--- a/src/Dev/DevelopmentAdmin.php
+++ b/src/Dev/DevelopmentAdmin.php
@@ -28,6 +28,12 @@ class DevelopmentAdmin extends Controller implements PermissionProvider
         '$Action' => 'runRegisteredController',
     ];
 
+    private static $init_permissions = [
+        'ADMIN',
+        'ALL_DEV_ADMIN',
+        'CAN_DEV_GRAPHQL',
+    ];
+
     protected function init()
     {
         parent::init();
@@ -104,7 +110,7 @@ class DevelopmentAdmin extends Controller implements PermissionProvider
             // We need to ensure that DevelopmentAdminTest can simulate permission failures when running
             // "dev/tasks" from CLI.
             || (Director::is_cli() && RootDevelopmentAdmin::config()->get('allow_all_cli'))
-            || Permission::check(['ADMIN', 'ALL_DEV_ADMIN', 'CAN_DEV_GRAPHQL'])
+            || Permission::check(static::config()->get('init_permissions'))
         );
     }
 


### PR DESCRIPTION
Companion PR to https://github.com/silverstripe/silverstripe-framework/pull/10979

Adds a fine-grained permission for `/dev/graphql`

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/10852