### PR TITLE
FIX QuerySort::sort method should support sorting for multi arguments

### DIFF
--- a/src/Schema/DataObject/Plugin/QuerySort.php
+++ b/src/Schema/DataObject/Plugin/QuerySort.php
@@ -102,6 +102,9 @@ class QuerySort extends AbstractQuerySortPlugin
             }
             $filterArgs = $args[$fieldName] ?? [];
             $paths = NestedInputBuilder::buildPathsFromArgs($filterArgs);
+            if (empty($paths)) {
+                return $list;
+            }
             $schemaContext = SchemaConfigProvider::get($context);
             if (!$schemaContext) {
                 throw new Exception(sprintf(
@@ -111,6 +114,7 @@ class QuerySort extends AbstractQuerySortPlugin
                 ));
             }
 
+            $normalisedPaths = [];
             foreach ($paths as $path => $value) {
                 $normalised = $schemaContext->mapPath($rootType, $path);
                 Schema::invariant(
@@ -120,10 +124,11 @@ class QuerySort extends AbstractQuerySortPlugin
                     $path,
                     $rootType
                 );
-                $list = $list->sort($normalised, $value);
+
+                $normalisedPaths[$normalised] = $value;
             }
 
-            return $list;
+            return $list->sort($normalisedPaths);
         };
     }
 

--- a/tests/Schema/_testFilterAndSort/models.yml
+++ b/tests/Schema/_testFilterAndSort/models.yml
@@ -5,8 +5,8 @@ SilverStripe\GraphQL\Tests\Fake\DataObjectFake:
         filter: true
         sort: true
   fields:
-    myField: true
     AuthorID: true
+    myField: true
     author:
       fields:
         firstName: true

--- a/tests/Schema/_testFilterAndSort/models.yml
+++ b/tests/Schema/_testFilterAndSort/models.yml
@@ -5,8 +5,8 @@ SilverStripe\GraphQL\Tests\Fake\DataObjectFake:
         filter: true
         sort: true
   fields:
-    AuthorID: true
     myField: true
+    AuthorID: true
     author:
       fields:
         firstName: true


### PR DESCRIPTION
## Description
Even if a method receives several parameters, then sorting occurs by the field of the arguments that is last specified in the schema, and not in the passed parameters. That is, if `SilverStripe\GraphQL\Tests\Fake\DataObjectFake` has the following schema
```yml
fields:
    myField: true
    AuthorID: true
```
and sorting is required `AuthorID => DESC, myField => ASC`, then sorting was done only by `AuthorID`, since in the schema this field is indicated after myField.
Therefore, the call `$list->sort()` must be completed after all the necessary processing has been carried out.

## Parent issue
- https://github.com/silverstripe/silverstripe-graphql/issues/561
