### PR TITLE
FIX QuerySort::sort method should support sorting for multi arguments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^7.4 || ^8.0",
         "silverstripe/framework": "^4.11",
         "silverstripe/vendor-plugin": "^1.0",
-        "webonyx/graphql-php": "^14.0",
+        "webonyx/graphql-php": "^14.11",
         "silverstripe/event-dispatcher": "^0.1.2",
         "guzzlehttp/guzzle": "^7.3",
         "guzzlehttp/psr7": "^2",

--- a/src/Schema/DataObject/Plugin/QuerySort.php
+++ b/src/Schema/DataObject/Plugin/QuerySort.php
@@ -18,6 +18,7 @@ use SilverStripe\ORM\DataObject;
 use Closure;
 use SilverStripe\ORM\Sortable;
 use Exception;
+use GraphQL\Type\Definition\ResolveInfo;
 
 /**
  * Adds a sort parameter to a DataObject query
@@ -87,7 +88,6 @@ class QuerySort extends AbstractQuerySortPlugin
         return $filters;
     }
 
-
     /**
      * @param array $context
      * @return Closure
@@ -96,12 +96,21 @@ class QuerySort extends AbstractQuerySortPlugin
     {
         $fieldName = $context['fieldName'];
         $rootType = $context['rootType'];
-        return function (?Sortable $list, array $args, array $context) use ($fieldName, $rootType) {
+        return function (?Sortable $list, array $args, array $context, ResolveInfo $info) use ($fieldName, $rootType) {
             if ($list === null) {
                 return null;
             }
-            $filterArgs = $args[$fieldName] ?? [];
-            $paths = NestedInputBuilder::buildPathsFromArgs($filterArgs);
+
+            if (!isset($args[$fieldName])) {
+                return $list;
+            }
+
+            $sortArgs = static::getSortArgs($info, $args, $rootType, $fieldName);
+            $paths = NestedInputBuilder::buildPathsFromArgs($sortArgs);
+            if (empty($paths)) {
+                return $list;
+            }
+
             $schemaContext = SchemaConfigProvider::get($context);
             if (!$schemaContext) {
                 throw new Exception(sprintf(
@@ -111,6 +120,7 @@ class QuerySort extends AbstractQuerySortPlugin
                 ));
             }
 
+            $normalisedPaths = [];
             foreach ($paths as $path => $value) {
                 $normalised = $schemaContext->mapPath($rootType, $path);
                 Schema::invariant(
@@ -120,11 +130,62 @@ class QuerySort extends AbstractQuerySortPlugin
                     $path,
                     $rootType
                 );
-                $list = $list->sort($normalised, $value);
+
+                $normalisedPaths[$normalised] = $value;
             }
 
-            return $list;
+            return $list->sort($normalisedPaths);
         };
+    }
+
+    private static function getSortArgs(ResolveInfo $info, array $args, string $rootType, string $fieldName): array
+    {
+        $sortArgs = [];
+        $sortOrder = self::getSortOrder($info, $fieldName);
+
+        foreach ($sortOrder as $orderName) {
+            if (!isset($args[$fieldName][$orderName])) {
+                continue;
+            }
+            $sortArgs[$orderName] = $args[$fieldName][$orderName];
+            unset($args[$fieldName][$orderName]);
+        }
+
+        return array_merge($sortArgs, $args[$fieldName]);
+    }
+
+    /**
+     * Gets the original order of fields to be sorted based on the query args order.
+     *
+     * This is necessary because the underlying GraphQL implementation we're using ignores the
+     * order of query args, and uses the order that fields are defined in the schema instead.
+     */
+    private static function getSortOrder(ResolveInfo $info, string $fieldName)
+    {
+        $relevantNode = $info->fieldDefinition->getName();
+
+        // Find the query field node that matches the schema
+        foreach ($info->fieldNodes as $node) {
+            if ($node->name->value !== $relevantNode) {
+                continue;
+            }
+
+            // Find the sort arg
+            foreach ($node->arguments as $arg) {
+                if ($arg->name->value !== $fieldName) {
+                    continue;
+                }
+
+                // Get the sort order from the query
+                $sortOrder = [];
+                foreach ($arg->value->fields as $field) {
+                    $sortOrder[] = $field->name->value;
+                }
+                return $sortOrder;
+            }
+        }
+
+        return [];
     }
 
     /**

--- a/tests/Schema/IntegrationTest.php
+++ b/tests/Schema/IntegrationTest.php
@@ -415,7 +415,100 @@ GRAPHQL;
         $this->assertMissingField($result, 'title');
     }
 
-    public function testFilterAndSort()
+    public function provideFilterAndSort(): array
+    {
+        return [
+            [
+                'query' => <<<GRAPHQL
+                query {
+                  readOneDataObjectFake(filter: { id: { eq: _ID_PLACEHOLDER_ } }) {
+                    id
+                  }
+                }
+                GRAPHQL,
+                'testAgainst' => 'id',
+                'placeholderRecord' => 'fake1',
+                'expected' => 'fake1',
+            ],
+            [
+                'query' => <<<GRAPHQL
+                query {
+                  readOneDataObjectFake(filter: { id: { ne: _ID_PLACEHOLDER_ } }) {
+                    id
+                  }
+                }
+                GRAPHQL,
+                'testAgainst' => 'id',
+                'placeholderRecord' => 'fake1',
+                'expected' => 'fake2',
+            ],
+            [
+                'query' => <<<GRAPHQL
+                query {
+                  readOneDataObjectFake(sort: { myField: ASC }) {
+                    myField
+                  }
+                }
+                GRAPHQL,
+                'testAgainst' => 'myField',
+                'placeholderRecord' => '',
+                'expected' => 'test1',
+            ],
+            [
+                'query' => <<<GRAPHQL
+                query {
+                  readOneDataObjectFake(sort: { AuthorID: DESC, myField: ASC }) {
+                    myField
+                  }
+                }
+                GRAPHQL,
+                'testAgainst' => 'myField',
+                'placeholderRecord' => '',
+                'expected' => 'test2',
+            ],
+            [
+              'query' => <<<GRAPHQL
+              query {
+                readOneDataObjectFake(sort: { myField: ASC, AuthorID: DESC }) {
+                  myField
+                }
+              }
+              GRAPHQL,
+              'testAgainst' => 'myField',
+              'placeholderRecord' => '',
+              'expected' => 'test1',
+            ],
+            [
+                'query' => <<<GRAPHQL
+                query {
+                  readOneDataObjectFake(sort: { myField: DESC }) {
+                    myField
+                  }
+                }
+                GRAPHQL,
+                'testAgainst' => 'myField',
+                'placeholderRecord' => '',
+                'expected' => 'test4',
+            ],
+            [
+                'query' => <<<GRAPHQL
+                query {
+                  readOneDataObjectFake(sort: { AuthorID: ASC, myField: DESC }, filter: { id: { ne: _ID_PLACEHOLDER_ } }) {
+                    myField
+                  }
+                }
+                GRAPHQL,
+                'testAgainst' => 'myField',
+                'placeholderRecord' => 'fake3',
+                'expected' => 'test4',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFilterAndSort
+     */
+    public function testFilterAndSort(string $query, string $testAgainst, string $placeholderRecord, string $expected): void
     {
         $dir = '_' . __FUNCTION__;
 
@@ -434,6 +527,9 @@ GRAPHQL;
         $dataObject3 = DataObjectFake::create(['MyField' => 'test3', 'AuthorID' => $author2->ID]);
         $dataObject3->write();
 
+        $dataObject4 = DataObjectFake::create(['MyField' => 'test4', 'AuthorID' => $author1->ID]);
+        $dataObject4->write();
+
         $file1 = File::create(['Title' => 'file1']);
         $file1->write();
 
@@ -446,104 +542,45 @@ GRAPHQL;
         $id1 = $dataObject1->ID;
         $id2 = $dataObject2->ID;
         $id3 = $dataObject3->ID;
+        $id4 = $dataObject4->ID;
+
+        if ($testAgainst === 'id') {
+            switch ($expected) {
+                case 'fake1':
+                    $expected = $id1;
+                    break;
+                case 'fake2':
+                    $expected = $id2;
+                    break;
+                case 'fake3':
+                    $expected = $id3;
+                    break;
+                default:
+                    throw new LogicException("No ID known for '$expected'");
+            }
+        }
+
+        $placeholderID = null;
+        switch ($placeholderRecord) {
+            case 'fake1':
+                $placeholderID = $id1;
+                break;
+            case 'fake2':
+                $placeholderID = $id2;
+                break;
+            case 'fake3':
+                $placeholderID = $id3;
+                break;
+        }
+        if ($placeholderID) {
+            $query = str_replace('_ID_PLACEHOLDER_', (string) $placeholderID, $query);
+        }
 
         $schema = $this->createSchema(new TestSchemaBuilder([$dir]));
 
-        $query = <<<GRAPHQL
-query {
-  readOneDataObjectFake(filter: { id: { eq: $id1 } }) {
-    id
-  }
-}
-GRAPHQL;
         $result = $this->querySchema($schema, $query);
         $this->assertSuccess($result);
-        $this->assertResult('readOneDataObjectFake.id', $id1, $result);
-
-        $query = <<<GRAPHQL
-query {
-  readOneDataObjectFake(filter: { id: { ne: $id1 } }) {
-    id
-  }
-}
-GRAPHQL;
-        $result = $this->querySchema($schema, $query);
-        $this->assertSuccess($result);
-        $this->assertResult('readOneDataObjectFake.id', $id2, $result);
-
-        $query = <<<GRAPHQL
-query {
-  readOneDataObjectFake(sort: { myField: ASC }) {
-    myField
-  }
-}
-GRAPHQL;
-        $result = $this->querySchema($schema, $query);
-        $this->assertSuccess($result);
-        $this->assertResult('readOneDataObjectFake.myField', 'test1', $result);
-
-        $query = <<<GRAPHQL
-query {
-  readOneDataObjectFake(sort: { AuthorID: DESC , myField: ASC }) {
-    myField
-  }
-}
-GRAPHQL;
-        $result = $this->querySchema($schema, $query);
-        $this->assertSuccess($result);
-        $this->assertResult('readOneDataObjectFake.myField', 'test2', $result);
-
-        $query = <<<GRAPHQL
-query {
-  readOneDataObjectFake(sort: { myField: DESC }) {
-    myField
-  }
-}
-GRAPHQL;
-        $result = $this->querySchema($schema, $query);
-        $this->assertSuccess($result);
-        $this->assertResult('readOneDataObjectFake.myField', 'test3', $result);
-
-        $query = <<<GRAPHQL
-query {
-  readOneDataObjectFake(sort: { myField: DESC }, filter: { id: { ne: $id3 } }) {
-    myField
-  }
-}
-GRAPHQL;
-        $result = $this->querySchema($schema, $query);
-        $this->assertSuccess($result);
-        $this->assertResult('readOneDataObjectFake.myField', 'test2', $result);
-
-        $query = <<<GRAPHQL
-query {
-  readOneDataObjectFake(filter: { author: { firstName: { eq: "tester1" } } }) {
-    id
-    author {
-      firstName
-    }
-  }
-}
-GRAPHQL;
-        $result = $this->querySchema($schema, $query);
-        // Nested fields aren't working. Needs refactoring.
-//        $this->assertSuccess($result);
-//        $this->assertResult('readOneDataObjectFake.author.firstName', 'tester1', $result);
-
-        $query = <<<GRAPHQL
-query {
-  readOneDataObjectFake(filter: { author: { firstName: { eq: "tester2" } } }) {
-    id
-    author {
-      firstName
-    }
-  }
-}
-GRAPHQL;
-        $result = $this->querySchema($schema, $query);
-
-//        $this->assertSuccess($result);
-//        $this->assertNull($result['data']['readOneDataObjectFake']);
+        $this->assertResult("readOneDataObjectFake.{$testAgainst}", $expected, $result);
     }
 
 
@@ -629,6 +666,61 @@ GRAPHQL;
         $this->assertSuccess($result);
         $this->assertResult('readOneDataObjectFake.myAliasedField', 'test2', $result);
         $this->assertResult('readOneDataObjectFake.author', null, $result);
+    }
+
+    public function provideFilterAndSortOnlyRead(): array
+    {
+        return [
+          'read with sort' => [
+            'fixture' => '_QuerySort',
+            'query' => <<<GRAPHQL
+            query {
+              readDataObjectFakes(sort: { author: { id: DESC }, myField: ASC }) {
+                nodes {
+                  myField
+                  author {
+                    firstName
+                  }
+                }
+              }
+            }
+            GRAPHQL,
+          ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFilterAndSortOnlyRead
+     */
+    public function testFilterAndSortOnlyRead($fixture, $query)
+    {
+        $author = Member::create(['FirstName' => 'tester1']);
+        $author->write();
+
+        $author2 = Member::create(['FirstName' => 'tester2']);
+        $author2->write();
+
+        $dataObject1 = DataObjectFake::create(['MyField' => 'test1', 'AuthorID' => $author->ID]);
+        $dataObject1->write();
+
+        $dataObject2 = DataObjectFake::create(['MyField' => 'test2', 'AuthorID' => $author2->ID]);
+        $dataObject2->write();
+
+        $dataObject3 = DataObjectFake::create(['MyField' => 'test3', 'AuthorID' => $author2->ID]);
+        $dataObject3->write();
+
+
+        $factory = new TestSchemaBuilder(['_' . __FUNCTION__ . $fixture]);
+        $schema = $this->createSchema($factory);
+
+        $result = $this->querySchema($schema, $query);
+        $this->assertSuccess($result);
+        $records = $result['data']['readDataObjectFakes']['nodes'] ?? [];
+        $this->assertResults([
+              ["myField" => "test2", "author" => ["firstName" => "tester2"]],
+              ["myField" => "test3", "author" => ["firstName" => "tester2"]],
+              ["myField" => "test1", "author" => ["firstName" => "tester1"]],
+        ], $records);
     }
 
     public function testAggregateProperties()

--- a/tests/Schema/_testFilterAndSortOnlyRead_QuerySort/models.yml
+++ b/tests/Schema/_testFilterAndSortOnlyRead_QuerySort/models.yml
@@ -1,0 +1,12 @@
+SilverStripe\GraphQL\Tests\Fake\DataObjectFake:
+  operations:
+    read:
+      plugins:
+        sort:
+          before: paginateList
+  fields:
+    myField: true
+    author:
+      fields:
+        id: true
+        firstName: true


### PR DESCRIPTION
## Description
Even if a method receives several parameters, then sorting occurs by the field of the arguments that is last specified in the schema, and not in the passed parameters. That is, if `SilverStripe\GraphQL\Tests\Fake\DataObjectFake` has the following schema
```yml
fields:
    myField: true
    AuthorID: true
```
and sorting is required `AuthorID => DESC, myField => ASC`, then sorting was done only by `AuthorID`, since in the schema this field is indicated after myField.
Therefore, the call `$list->sort()` must be completed after all the necessary processing has been carried out.

## Parent issue
- https://github.com/silverstripe/silverstripe-graphql/issues/561