### PR TITLE
[CVE-2023-44401] Ensure canView() checks are run

### DIFF
--- a/tests/Fake/FakeDataObjectWithCanView.php
+++ b/tests/Fake/FakeDataObjectWithCanView.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SilverStripe\GraphQL\Tests\Fake;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class FakeDataObjectWithCanView extends DataObject implements TestOnly
+{
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
+
+    private static $table_name = 'FakeDataObjectWithCanView_Test';
+
+    public function canView($member = null)
+    {
+        return $this->ID % 2;
+    }
+}

--- a/tests/Schema/_testCanViewPagination/schema.yml
+++ b/tests/Schema/_testCanViewPagination/schema.yml
@@ -1,0 +1,8 @@
+models:
+  SilverStripe\GraphQL\Tests\Fake\FakeDataObjectWithCanView:
+    fields: '*'
+    operations:
+      read:
+        plugins:
+          paginateList: true
+          canView: true


### PR DESCRIPTION
This should match https://github.com/silverstripe-security/silverstripe-graphql/pull/18 exactly

CI has already passed in the security repository. Any CI failures that are present there are expected and accounted for. This can be merged safely without waiting for CI to run again. CI will run after merging anyway, and is a safeguard prior to patching.

## Issues
- https://github.com/silverstripeltd/product-issues/issues/832
- https://github.com/silverstripe-security/security-issues/issues/172