### PR TITLE
FIX: Don't attempt to correct sort when passed as an argument (closes #571)

### DIFF
--- a/_config/logging.yml
+++ b/_config/logging.yml
@@ -4,5 +4,11 @@ after: '#logging'
 ---
 
 SilverStripe\Core\Injector\Injector:
+  # Omits the HTTPOutputHandler from the logger so errors won't appear in output
+  Psr\Log\LoggerInterface.graphql-quiet:
+    type: singleton
+    class: Monolog\Logger
+    constructor:
+      - 'graphql'
   # This will occasionally be overridden with SilverStripe\GraphQL\Schema\Logger to provide a nicer output on schema build task
   Psr\Log\LoggerInterface.graphql-build: '%$Psr\Log\LoggerInterface.errorhandler'

--- a/src/Schema/Traits/SortTrait.php
+++ b/src/Schema/Traits/SortTrait.php
@@ -2,7 +2,10 @@
 
 namespace SilverStripe\GraphQL\Schema\Traits;
 
+use GraphQL\Language\AST\ObjectValueNode;
 use GraphQL\Type\Definition\ResolveInfo;
+use Psr\Log\LoggerInterface;
+use SilverStripe\Core\Injector\Injector;
 
 trait SortTrait
 {
@@ -41,6 +44,14 @@ trait SortTrait
             // Find the sort arg
             foreach ($node->arguments as $arg) {
                 if ($arg->name->value !== $fieldName) {
+                    continue;
+                }
+
+                // If the sort has been passed as a variable, we can't attempt to fix it
+                // See https://github.com/silverstripe/silverstripe-graphql/issues/573
+                if (!$arg->value instanceof ObjectValueNode) {
+                    $logger = Injector::inst()->get(LoggerInterface::class . '.graphql-quiet');
+                    $logger->warning('Unable to adjust sort order, sort fields may be applied in incorrect order.');
                     continue;
                 }
 

--- a/tests/Schema/IntegrationTest.php
+++ b/tests/Schema/IntegrationTest.php
@@ -847,6 +847,112 @@ GRAPHQL;
         $this->assertResults($expected, $records);
     }
 
+    public function provideFilterAndSortWithArgsOnlyRead(): array
+    {
+        return [
+            'read with sort - with sort arg' => [
+                'fixture' => '_QuerySort',
+                'query' => <<<GRAPHQL
+query (\$sort: DataObjectFakeSortFields) {
+  readDataObjectFakes(sort: \$sort) {
+    nodes {
+      myField
+      author {
+        firstName
+      }
+    }
+  }
+}
+GRAPHQL,
+                'args' => [
+                    'sort' => ['author' => ['id' => 'DESC'], 'myField' => 'ASC']
+                ],
+                'expected' => [
+                    ["myField" => "test2", "author" => ["firstName" => "tester2"]],
+                    ["myField" => "test3", "author" => ["firstName" => "tester2"]],
+                    ["myField" => "test1", "author" => ["firstName" => "tester1"]],
+                ],
+            ],
+            'read with sorter files ParentID DESC, name ASC - with sort args' => [
+                'fixture' => '_SortPlugin',
+                'query' => <<<GRAPHQL
+query (\$sort: DataObjectFakeSortFields, \$fileSort: FilesSimpleSortFields) {
+  readDataObjectFakes(sort: \$sort) {
+    nodes {
+      myField
+      files(sort: \$fileSort) {
+        title
+      }
+    }
+  }
+}
+GRAPHQL,
+                'args' => [
+                    'sort' => ['myField' => 'ASC'],
+                    'fileSort' => ['ParentID' => 'DESC', 'name' => 'ASC'],
+                ],
+                'expected' => [
+                    ["myField" => "test1", "files" => [["title" => "file2"], ["title" => "file4"], ["title" => "file1"], ["title" => "file3"]]],
+                    ["myField" => "test2", "files" => []],
+                    ["myField" => "test3", "files" => []],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideFilterAndSortWithArgsOnlyRead
+     */
+    public function testFilterAndSortWithArgsOnlyRead(string $fixture, string $query, array $args, array $expected)
+    {
+        $author = Member::create(['FirstName' => 'tester1']);
+        $author->write();
+
+        $author2 = Member::create(['FirstName' => 'tester2']);
+        $author2->write();
+
+        $dataObject1 = DataObjectFake::create(['MyField' => 'test1', 'AuthorID' => $author->ID]);
+        $dataObject1->write();
+
+        $dataObject2 = DataObjectFake::create(['MyField' => 'test2', 'AuthorID' => $author2->ID]);
+        $dataObject2->write();
+
+        $dataObject3 = DataObjectFake::create(['MyField' => 'test3', 'AuthorID' => $author2->ID]);
+        $dataObject3->write();
+
+        $file1 = File::create(['Title' => 'file1', 'Name' => 'asc_name']);
+        $file1->ParentID = 1;
+        $file1->write();
+
+        $file2 = File::create(['Title' => 'file2', 'Name' => 'desc_name']);
+        $file2->ParentID = 1;
+        $file2->write();
+
+        $file3 = File::create(['Title' => 'file3', 'Name' => 'asc_name']);
+        $file3->ParentID = 2;
+        $file3->write();
+
+        $file4 = File::create(['Title' => 'file4', 'Name' => 'desc_name']);
+        $file4->ParentID = 2;
+        $file4->write();
+
+        $dataObject1->Files()->add($file1);
+        $dataObject1->Files()->add($file2);
+        $dataObject1->Files()->add($file3);
+        $dataObject1->Files()->add($file4);
+
+        $factory = new TestSchemaBuilder(['_' . __FUNCTION__ . $fixture]);
+        $schema = $this->createSchema($factory);
+
+        $result = $this->querySchema($schema, $query, $args);
+        $this->assertSuccess($result);
+        $records = $result['data']['readDataObjectFakes']['nodes'] ?? [];
+
+        // We intentionally don't check the sort order, as it's expected it may not match:
+        // See https://github.com/silverstripe/silverstripe-graphql/issues/573
+        $this->assertEqualsCanonicalizing($expected, $records);
+    }
+
     public function testAggregateProperties()
     {
         $file1 = File::create(['Title' => '1']);

--- a/tests/Schema/_testFilterAndSortWithArgsOnlyRead_QuerySort/models.yml
+++ b/tests/Schema/_testFilterAndSortWithArgsOnlyRead_QuerySort/models.yml
@@ -1,0 +1,12 @@
+SilverStripe\GraphQL\Tests\Fake\DataObjectFake:
+  operations:
+    read:
+      plugins:
+        sort:
+          before: paginateList
+  fields:
+    myField: true
+    author:
+      fields:
+        id: true
+        firstName: true

--- a/tests/Schema/_testFilterAndSortWithArgsOnlyRead_SortPlugin/models.yml
+++ b/tests/Schema/_testFilterAndSortWithArgsOnlyRead_SortPlugin/models.yml
@@ -1,0 +1,22 @@
+SilverStripe\GraphQL\Tests\Fake\DataObjectFake:
+  operations:
+    read:
+      plugins:
+        sort:
+          before: paginateList
+  fields:
+    myField: true
+    AuthorID: true
+    author:
+      fields:
+        firstName: true
+    files:
+      fields:
+        title: true
+      plugins:
+        sorter:
+          fields:
+            id: true
+            title: true
+            name: true
+            ParentID: true


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
Proposed fix for #571. Doesn’t actually solve the underlying issue, but prevents the warnings being emitted by `SortTrait`.

## Manual testing steps
N/A

## Issues
- #571

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
