### PR TITLE
API Add Directive types

### DIFF
--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -37,6 +37,7 @@ use SilverStripe\GraphQL\Schema\Type\UnionType;
 use SilverStripe\ORM\ArrayLib;
 use Exception;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\GraphQL\Schema\Type\Directive;
 use TypeError;
 
 /**
@@ -62,6 +63,7 @@ class Schema implements ConfigurationApplier
     const UNIONS = 'unions';
     const ENUMS = 'enums';
     const SCALARS = 'scalars';
+    const DIRECTIVES = 'directives';
     const QUERY_TYPE = 'Query';
     const MUTATION_TYPE = 'Mutation';
     const ALL = '*';
@@ -108,6 +110,11 @@ class Schema implements ConfigurationApplier
      */
     private array $scalars = [];
 
+    /**
+     * @var Directive[]
+     */
+    private array $directives = [];
+
     private Type $queryType;
 
     private Type $mutationType;
@@ -151,6 +158,7 @@ class Schema implements ConfigurationApplier
             self::MODELS,
             self::ENUMS,
             self::SCALARS,
+            self::DIRECTIVES,
             self::SCHEMA_CONFIG,
             'execute',
             self::SOURCE,
@@ -166,6 +174,7 @@ class Schema implements ConfigurationApplier
         $models = $schemaConfig[self::MODELS] ?? [];
         $enums = $schemaConfig[self::ENUMS] ?? [];
         $scalars = $schemaConfig[self::SCALARS] ?? [];
+        $directives = $schemaConfig[self::DIRECTIVES] ?? [];
         $config = $schemaConfig[self::SCHEMA_CONFIG] ?? [];
 
 
@@ -247,6 +256,13 @@ class Schema implements ConfigurationApplier
         foreach ($scalars as $scalarName => $scalarConfig) {
             $scalar = Scalar::create($scalarName, $scalarConfig);
             $this->addScalar($scalar);
+        }
+
+        static::assertValidConfig($directives);
+        foreach ($directives as $directiveName => $directiveConfig) {
+            static::assertValidConfig($directiveConfig, ['name', 'description', 'args', 'locations']);
+            $directive = Directive::create($directiveName, $directiveConfig);
+            $this->addDirective($directive);
         }
 
         $this->applyProceduralUpdates($config['execute'] ?? []);
@@ -569,7 +585,8 @@ class Schema implements ConfigurationApplier
                 self::ENUMS => $this->getEnums(),
                 self::INTERFACES => $this->getInterfaces(),
                 self::UNIONS => $this->getUnions(),
-                self::SCALARS => $this->getScalars()
+                self::SCALARS => $this->getScalars(),
+                self::DIRECTIVES => $this->getDirectives()
             ],
             $this->getConfig()
         );
@@ -754,6 +771,22 @@ class Schema implements ConfigurationApplier
     public function removeScalar(string $name): self
     {
         unset($this->scalars[$name]);
+        return $this;
+    }
+
+    public function getDirectives(): array
+    {
+        return $this->directives;
+    }
+
+    public function getDirective(string $name): ?Directive
+    {
+        return $this->directives[$name] ?? null;
+    }
+
+    public function addDirective(Directive $directive): self
+    {
+        $this->directives[$directive->getName()] = $directive;
         return $this;
     }
 

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -219,6 +219,7 @@ class SchemaBuilder
             Schema::INTERFACES => [],
             Schema::UNIONS => [],
             Schema::SCALARS => [],
+            Schema::DIRECTIVES => [],
         ];
 
         $finder = new Finder();

--- a/src/Schema/StorableSchema.php
+++ b/src/Schema/StorableSchema.php
@@ -6,6 +6,7 @@ namespace SilverStripe\GraphQL\Schema;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
 use SilverStripe\GraphQL\Schema\Interfaces\SchemaValidator;
+use SilverStripe\GraphQL\Schema\Type\Directive;
 use SilverStripe\GraphQL\Schema\Type\Enum;
 use SilverStripe\GraphQL\Schema\Type\InterfaceType;
 use SilverStripe\GraphQL\Schema\Type\Scalar;
@@ -50,6 +51,11 @@ class StorableSchema implements SchemaValidator
      */
     private array $scalars;
 
+    /**
+     * @var Directive[]
+     */
+    private array $directives;
+
     private SchemaConfig $config;
 
     public function __construct(array $config = [], ?SchemaConfig $context = null)
@@ -59,6 +65,7 @@ class StorableSchema implements SchemaValidator
         $this->interfaces = $config[Schema::INTERFACES] ?? [];
         $this->unions = $config[Schema::UNIONS] ?? [];
         $this->scalars = $config[Schema::SCALARS] ?? [];
+        $this->directives = $config[Schema::DIRECTIVES] ?? [];
         $this->config = $context ?: SchemaConfig::create();
     }
 
@@ -102,6 +109,14 @@ class StorableSchema implements SchemaValidator
         return $this->scalars;
     }
 
+    /**
+     * @return Directive[]
+     */
+    public function getDirectives(): array
+    {
+        return $this->directives;
+    }
+
     public function getConfig(): SchemaConfig
     {
         return $this->config;
@@ -137,7 +152,8 @@ class StorableSchema implements SchemaValidator
             array_keys($this->enums ?? []),
             array_keys($this->interfaces ?? []),
             array_keys($this->unions ?? []),
-            array_keys($this->scalars ?? [])
+            array_keys($this->scalars ?? []),
+            array_keys($this->directives ?? [])
         );
         $dupes = [];
         foreach (array_count_values($allNames ?? []) as $val => $count) {
@@ -170,7 +186,8 @@ class StorableSchema implements SchemaValidator
             $this->enums,
             $this->interfaces,
             $this->unions,
-            $this->scalars
+            $this->scalars,
+            $this->directives
         );
         /* @var SchemaValidator $validator */
         foreach ($validators as $validator) {

--- a/src/Schema/Storage/CodeGenerationStore.php
+++ b/src/Schema/Storage/CodeGenerationStore.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\GraphQL\Schema\Storage;
 
 use Exception;
+use GraphQL\GraphQL;
 use GraphQL\Type\Schema as GraphQLSchema;
 use GraphQL\Type\SchemaConfig as GraphQLSchemaConfig;
 use Psr\Log\LoggerInterface;
@@ -29,6 +30,7 @@ class CodeGenerationStore implements SchemaStorageInterface
     use Configurable;
 
     const TYPE_CLASS_NAME = 'Types';
+    const DIRECTIVE_CLASS_NAME = 'Directives';
 
     /**
      * @config
@@ -137,6 +139,8 @@ class CodeGenerationStore implements SchemaStorageInterface
             'typeClassName' => self::TYPE_CLASS_NAME,
             'namespace' => $this->getNamespace(),
             'obfuscator' => $obfuscator,
+            'directiveClassName' => self::DIRECTIVE_CLASS_NAME,
+            'directives' => $schema->getDirectives()
         ];
 
         $config = $schema->getConfig()->toArray();
@@ -146,10 +150,10 @@ class CodeGenerationStore implements SchemaStorageInterface
             $fs->dumpFile(
                 $configFile,
                 '<?php ' .
-                PHP_EOL .
-                'return ' .
-                var_export($config, true) .
-                ';'
+                    PHP_EOL .
+                    'return ' .
+                    var_export($config, true) .
+                    ';'
             );
         } catch (IOException $e) {
             throw new RuntimeException(sprintf(
@@ -164,7 +168,8 @@ class CodeGenerationStore implements SchemaStorageInterface
             $schema->getEnums(),
             $schema->getInterfaces(),
             $schema->getUnions(),
-            $schema->getScalars()
+            $schema->getScalars(),
+            $schema->getDirectives(),
         );
         $encoder = Encoder::create(Path::join($templateDir, 'registry.inc.php'), $allComponents, $globals);
         $code = $encoder->encode();
@@ -185,13 +190,14 @@ class CodeGenerationStore implements SchemaStorageInterface
             'Unions' => 'union.inc.php',
             'Enums' => 'enum.inc.php',
             'Scalars' => 'scalar.inc.php',
+            'Directives' => 'directive.inc.php',
         ];
         $touched = [];
         $built = [];
         $total = 0;
         foreach ($fields as $field => $template) {
             $method = 'get' . $field;
-            /* @var Type|InterfaceType|UnionType|Enum $type */
+            /* @var Type|InterfaceType|UnionType|Enum|Directive $type */
             foreach ($schema->$method() as $type) {
                 $total++;
                 $name = $type->getName();
@@ -310,6 +316,11 @@ class CodeGenerationStore implements SchemaStorageInterface
         }, $typeNames ?? []);
 
         $schemaConfig->setTypes($typeObjs);
+
+        $directivesClass = $this->getClassName(self::DIRECTIVE_CLASS_NAME);
+        $directives = call_user_func([$directivesClass, Schema::DIRECTIVES]);
+        $directives = array_merge(GraphQL::getStandardDirectives(), $directives);
+        $schemaConfig->setDirectives($directives);
 
         $this->graphqlSchema = new GraphQLSchema($schemaConfig);
 

--- a/src/Schema/Storage/templates/directive.inc.php
+++ b/src/Schema/Storage/templates/directive.inc.php
@@ -1,0 +1,43 @@
+<?php
+/* @var object $scope */
+/* @var \SilverStripe\GraphQL\Schema\Type\Directive $directive */
+/* @var array $globals */
+?>
+<?php $directive = $scope; ?>
+namespace <?=$globals['namespace']; ?>;
+
+use GraphQL\Type\Definition\Directive;
+
+// @type:<?=$directive->getName(); ?>
+
+class <?=$globals['obfuscator']->obfuscate($directive->getName()) ?> extends Directive
+{
+    public function __construct()
+    {
+        parent::__construct([
+            'name' => '<?=$directive->getName() ?>',
+        <?php if (!empty($directive->getDescription())) : ?>
+            'description' => '<?=addslashes($directive->getDescription()); ?>',
+        <?php endif; ?>
+
+        'locations' => [
+        <?php foreach ($directive->getLocations() as $location) : ?>
+            '<?=$location; ?>',
+        <?php endforeach; ?>
+        ], // locations
+        <?php if (!empty($directive->getArgs())) : ?>
+            'args' => [
+            <?php foreach ($directive->getArgs() as $arg) : ?>
+                [
+                    'name' => '<?=$arg->getName(); ?>',
+                    'type' => <?=$arg->getEncodedType()->encode(); ?>,
+                <?php if ($arg->getDefaultValue() !== null) : ?>
+                    'defaultValue' => <?=var_export($arg->getDefaultValue(), true); ?>,
+                <?php endif; ?>
+                ], // arg
+            <?php endforeach; ?>
+            ], // args
+        <?php endif; ?>
+        ]);
+    }
+}

--- a/src/Schema/Storage/templates/registry.inc.php
+++ b/src/Schema/Storage/templates/registry.inc.php
@@ -26,3 +26,27 @@ public static function <?=$component->getName(); ?>() { return static::get('<?=$
     <?php endforeach; ?>
 
 }
+
+class <?=$globals['directiveClassName']; ?> extends AbstractTypeRegistry
+{
+    protected static $types = [];
+
+    protected static function getSourceDirectory(): string
+    {
+        return __DIR__;
+    }
+
+    protected static function getSourceNamespace(): string
+    {
+        return __NAMESPACE__;
+    }
+
+    public static function directives() {
+        return [
+        <?php foreach ($globals['directives'] as $directive) : ?>
+            static::get('<?=$directive->getName(); ?>'),
+        <?php endforeach; ?>
+        ];
+    }
+
+}

--- a/src/Schema/Type/Directive.php
+++ b/src/Schema/Type/Directive.php
@@ -1,0 +1,154 @@
+<?php
+
+
+namespace SilverStripe\GraphQL\Schema\Type;
+
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\GraphQL\Schema\Exception\SchemaBuilderException;
+use SilverStripe\GraphQL\Schema\Field\Argument;
+use SilverStripe\GraphQL\Schema\Interfaces\ConfigurationApplier;
+use SilverStripe\GraphQL\Schema\Interfaces\SchemaComponent;
+use SilverStripe\GraphQL\Schema\Interfaces\SchemaValidator;
+use SilverStripe\GraphQL\Schema\Interfaces\SignatureProvider;
+use SilverStripe\GraphQL\Schema\Schema;
+use GraphQL\Language\DirectiveLocation;
+
+class Directive implements ConfigurationApplier, SchemaValidator, SignatureProvider, SchemaComponent
+{
+    use Injectable;
+    use Configurable;
+
+    private string $name;
+    private ?string $description = null;
+    private array $locations;
+    private array $args = [];
+
+    /**
+     * @throws SchemaBuilderException
+     */
+    public function __construct(string $directiveName, array $config = [])
+    {
+        $this->setName($directiveName);
+        $this->applyConfig($config);
+    }
+
+    public function applyConfig(array $config): void
+    {
+        Schema::assertValidConfig($config, [
+            'name',
+            'description',
+            'locations',
+            'args',
+        ]);
+
+        if (isset($config['name'])) {
+            $this->setName($config['name']);
+        }
+
+        if (isset($config['description'])) {
+            $this->setDescription($config['description']);
+        }
+
+        $locations = $config['locations'] ?? [DirectiveLocation::FIELD];
+        $this->setLocations($locations);
+
+        if (isset($config['args'])) {
+            $this->setArgs($config['args']);
+        }
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @throws SchemaBuilderException
+     */
+    public function setName(string $name): self
+    {
+        Schema::assertValidName($name);
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description)
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    public function getLocations(): array
+    {
+        return $this->locations;
+    }
+
+    /**
+     * @param string $argName
+     * @param null $config
+     * @param callable|null $callback
+     * @return Directive
+     */
+    public function setLocations(array $locations): self
+    {
+        $this->locations = $locations;
+        return $this;
+    }
+
+    public function getArgs(): array
+    {
+        return $this->args;
+    }
+
+    /**
+     * @param string $argName
+     * @param null $config
+     * @param callable|null $callback
+     * @return Directive
+     */
+    public function addArg(string $argName, $config, ?callable $callback = null): self
+    {
+        $argObj = $config instanceof Argument ? $config : Argument::create($argName, $config);
+        $this->args[$argObj->getName()] = $argObj;
+        if ($callback) {
+            call_user_func_array($callback, [$argObj]);
+        }
+        return $this;
+    }
+
+    /**
+     * @param array $args
+     * @return $this
+     * @throws SchemaBuilderException
+     */
+    public function setArgs(array $args): self
+    {
+        Schema::assertValidConfig($args);
+        foreach ($args as $argName => $config) {
+            if ($config === false) {
+                continue;
+            }
+            $this->addArg($argName, $config);
+        }
+
+        return $this;
+    }
+
+    public function validate(): void
+    {
+    }
+
+    public function getSignature(): string
+    {
+        return md5(json_encode([
+            $this->getName(),
+            $this->getDescription(),
+        ]) ?? '');
+    }
+}

--- a/tests/Schema/IntegrationTest.php
+++ b/tests/Schema/IntegrationTest.php
@@ -1450,6 +1450,26 @@ GRAPHQL;
         $this->assertResult('readOneDataObjectFake.id', $id1, $result);
     }
 
+    public function testDirectives()
+    {
+        $dataObject1 = DataObjectFake::create([]);
+        $dataObject1->write();
+
+        $schema = $this->createSchema(new TestSchemaBuilder(['_' . __FUNCTION__]));
+
+        $query = <<<GRAPHQL
+query @testQueryDirective {
+  readOneDataObjectFake @testFieldDirective {
+    id
+  }
+}
+GRAPHQL;
+        $result = $this->querySchema($schema, $query);
+        // The GraphQL server throws errors for unknown directives.
+        // A simple assertion on the result proves that directive was processed successfully.
+        $this->assertSuccess($result);
+    }
+
     public function testHtaccess(): void
     {
         FakeProductPage::get()->removeAll();

--- a/tests/Schema/SchemaTest.php
+++ b/tests/Schema/SchemaTest.php
@@ -15,12 +15,14 @@ use SilverStripe\GraphQL\Schema\Type\Enum;
 use SilverStripe\GraphQL\Schema\Type\InterfaceType;
 use SilverStripe\GraphQL\Schema\Type\ModelType;
 use SilverStripe\GraphQL\Schema\Type\Scalar;
+use SilverStripe\GraphQL\Schema\Type\Directive;
 use SilverStripe\GraphQL\Schema\Type\Type;
 use SilverStripe\GraphQL\Schema\Type\UnionType;
 use SilverStripe\GraphQL\Tests\Fake\DataObjectFake;
 use SilverStripe\GraphQL\Tests\Fake\FakePage;
 use SilverStripe\GraphQL\Tests\Fake\FakeSiteTree;
 use SilverStripe\GraphQL\Tests\Fake\SubFake\FakePage as SubFakePage;
+use GraphQL\Language\DirectiveLocation;
 
 class SchemaTest extends SapphireTest
 {
@@ -46,7 +48,7 @@ class SchemaTest extends SapphireTest
     {
         $mock = $this->getMockBuilder(Schema::class)
             ->setConstructorArgs(['test', $this->createSchemaContext()])
-            ->setMethods(['addType', 'addInterface', 'addUnion', 'addModel', 'addEnum', 'addScalar'])
+            ->setMethods(['addType', 'addInterface', 'addUnion', 'addModel', 'addEnum', 'addScalar', 'addDirective'])
             ->getMock();
         $mock
             ->expects($this->exactly(3))
@@ -73,6 +75,10 @@ class SchemaTest extends SapphireTest
             ->expects($this->once())
             ->method('addScalar')
             ->with($this->isInstanceOf(Scalar::class));
+        $mock
+            ->expects($this->once())
+            ->method('addDirective')
+            ->with($this->isInstanceOf(Directive::class));
 
         $config = $this->getValidConfig();
         $mock->applyConfig($config);
@@ -362,6 +368,13 @@ class SchemaTest extends SapphireTest
             'mutations' => [
                 'mutation1' => 'testtype3',
             ],
+            'directives' => [
+                'directive1' => [
+                    'locations' => [
+                        DirectiveLocation::FIELD
+                    ]
+                ]
+            ]
         ];
     }
 

--- a/tests/Schema/_testDirectives/schema.yml
+++ b/tests/Schema/_testDirectives/schema.yml
@@ -1,0 +1,14 @@
+models:
+  SilverStripe\GraphQL\Tests\Fake\DataObjectFake:
+    operations:
+      readOne: true
+directives:
+  testQueryDirective:
+    description: 'test description'
+    args:
+      if:
+        type: Boolean
+        defaultValue: true
+    locations: [QUERY]
+  testFieldDirective:
+    locations: [FIELD]


### PR DESCRIPTION
This PR is working as intended for my use case and can be merged in. However, I have a note for the maintainers here to make the decision on. I'm currently using this as a patch in our codebase on version 4.13 of this module. I'm hoping that it can be merged in by the time I'm done with our codebase migration and can then bump up to v5 of this module.

SchemaTransciber [does not introspect the directives](https://github.com/silverstripe/silverstripe-graphql/blob/5/src/Schema/Services/SchemaTranscriber.php#L97). Therefore users relying on the schema transcriber won't be able to get the full schema including the directives. I can't make the decision on behalf of the framework on how much you want added within the introspection query.  I personally don't use it, we generate the schema directly using @graphql-codegen and that introspects what we need. An example of a more comprehensive introspection query can be found [here](https://github.com/graphql/graphql-js/blob/main/src/utilities/getIntrospectionQuery.ts#L41) and what the directives field may contain [here](https://github.com/graphql/graphql-js/blob/main/src/utilities/getIntrospectionQuery.ts#L76). That introspect query also adds the complexity of configuration, so I'm not really sure what you guys would want here. As I said, this feature as-is is enough for me at the moment.

<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Directives are part of the GraphQL specification and this PR adds the Directive type for developers to create custom ones. Ideally, this PR would be followed up (or done alongside) with more integration of directives. One use case i would like to see is adding `deprecationReason` to to types.
```yaml
types:
  myType:
    fields: {}
    deprecationReason: Use goodType instead
```
or if there is any reason to add directives to a field (not sure if this is a valid use case)
```yaml
types:
  myType:
    fields: {}
    directives:
      deprecated:
        deprecationReason: Use goodType instead
```

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
A new type is added `directives` in the graphql schema yaml file.
```yaml
---
directives:
  myDirective:
    description: 'Optional description'
    args:
      if:
        type: Boolean
        defaultValue: true
    locations: [QUERY]
```

Viewing the the graphql schema (e.g. using /dev/graphql/ide) should now contain an entry like so:
```
# Optional description
directive @myDirective(if: Boolean = true) on QUERY
```

The configuration of the `Directive` type can be found here https://webonyx.github.io/graphql-php/type-definitions/directives/#custom-directives.

The directive can then be resolved within the resolver like so:
```php
/** @var ResolveInfo $info */
$allDirectives = $info->operation?->directives?->getIterator() ?? [];
foreach ($allDirectives as $directive) {
  var_dump($directive->name->value);
}
```

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #578

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
