### PR TITLE
MNT Fix lint failure in test

### DIFF
--- a/tests/Schema/AbstractTypeRegistryTest.php
+++ b/tests/Schema/AbstractTypeRegistryTest.php
@@ -140,7 +140,7 @@ class AbstractTypeRegistryTest extends SapphireTest
 
     private function getInstance()
     {
-        $registry = new Class extends AbstractTypeRegistry
+        $registry = new class extends AbstractTypeRegistry
         {
             protected static function getSourceDirectory(): string
             {


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-graphql/actions/runs/11002947177/job/30551276517

> PHP keywords must be lowercase; expected "class" but found "Class"

## Issue
- https://github.com/silverstripe/.github/issues/313