### PR TITLE
MNT Fix test that didn't account for i18n spaces

### DIFF
--- a/tests/Schema/IntegrationTest.php
+++ b/tests/Schema/IntegrationTest.php
@@ -1434,8 +1434,8 @@ GRAPHQL;
         $node = $result['data']['readOneDataObjectFake'] ?? null;
         $this->assertEquals('This is a varchar field', $node['myField']);
         $this->assertEquals('Saturday', $node['date1']);
-        $this->assertEquals('2/29/20, 5:00 PM', $node['date2']);
-        $this->assertEquals('5:00:00 PM', $node['date3']);
+        $this->assertMatchesRegularExpression('#2/29/20,\h5:00\hPM#u', $node['date2']);
+        $this->assertMatchesRegularExpression('#5:00:00\hPM#u', $node['date3']);
         $this->assertEquals('2020', $node['date4']);
         $this->assertEquals('This is a really long text field. It has a few sentences.', $node['myText']);
     }


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-graphql/actions/runs/11061549418/job/30734504257?pr=610

> 1) SilverStripe\GraphQL\Tests\Schema\IntegrationTest::testDBFieldArgs
> Failed asserting that two strings are equal.
> --- Expected
> +++ Actual
> @@ @@
> -'2/29/20, 5:00 PM'
> +'2/29/20, 5:00 PM'

The date formatter used is `IntlDateFormatter` which sometimes uses narrow non-breaking spaces. These are valid, given the intention of using `IntlDateFormatter` is to give a format that is correct for the locale used on the front-end, and in some locales the narrow non-breaking space is correct.

This test doesn't have to care what specific spaces are used - just that the correct date is there in the correct format.

## Issue
- https://github.com/silverstripe/.github/issues/313