### PR TITLE
MNT Don't test behat from other modules anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,3 @@ jobs:
   ci:
     name: CI
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
-    with:
-      extra_jobs: |
-        - php: 8.3
-          endtoend: true
-          endtoend_suite: asset-admin
-          endtoend_config: vendor/silverstripe/asset-admin/behat.yml
-        - php: 8.3
-          endtoend: true
-          endtoend_suite: versioned-admin
-          endtoend_config: vendor/silverstripe/versioned-admin/behat.yml
-        - php: 8.3
-          endtoend: true
-          endtoend_suite: silverstripe-elemental
-          endtoend_config: vendor/dnadesign/silverstripe-elemental/behat.yml


### PR DESCRIPTION
The behat runs had intermittent failures.

This module used to be used by those modules, so these behat runs validated changes in graphql didn't break those modules.

They don't do that anymore, so these behat runs are pointless here.

## Issue
- https://github.com/silverstripe/.github/issues/348