### PR TITLE
DEP Add conflict with elemental 6.0.0-alpha1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
         "silverstripe/standards": "^1",
         "phpstan/extension-installer": "^1.3"
     },
+    "conflict": {
+        "dnadesign/silverstripe-elemental": "6.0.0-alpha1"
+    },
     "autoload": {
         "psr-4": {
             "SilverStripe\\GraphQL\\": "src/",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

Fixes https://github.com/silverstripe/silverstripe-graphql/actions/runs/12401081001/job/34624044675#step:12:95 where elemental 6.0.0-alpha1 is being installed

 PHP Fatal error:  Could not check compatibility between DNADesign\Elemental\Tests\Blocks\TestElementContent::getCMSCompositeValidator(): SilverStripe\Forms\CompositeValidator and SilverStripe\ORM\DataObject::getCMSCompositeValidator(): SilverStripe\Forms\Validation\CompositeValidator, because class SilverStripe\Forms\CompositeValidator is not available in /home/runner/work/silverstripe-graphql/silverstripe-graphql/vendor/dnadesign/silverstripe-elemental/tests/Blocks/TestElementContent.php on line 56

This blocks 6.0.0-alpha1 so that 6.0.0-x-dev is installed instead