### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/Schema/AbstractTypeRegistryTest.php
+++ b/tests/Schema/AbstractTypeRegistryTest.php
@@ -140,7 +140,7 @@ class AbstractTypeRegistryTest extends SapphireTest
 
     private function getInstance()
     {
-        $registry = new Class extends AbstractTypeRegistry
+        $registry = new class extends AbstractTypeRegistry
         {
             protected static function getSourceDirectory(): string
             {

--- a/tests/Schema/IntegrationTest.php
+++ b/tests/Schema/IntegrationTest.php
@@ -1434,8 +1434,8 @@ GRAPHQL;
         $node = $result['data']['readOneDataObjectFake'] ?? null;
         $this->assertEquals('This is a varchar field', $node['myField']);
         $this->assertEquals('Saturday', $node['date1']);
-        $this->assertEquals('2/29/20, 5:00 PM', $node['date2']);
-        $this->assertEquals('5:00:00 PM', $node['date3']);
+        $this->assertMatchesRegularExpression('#2/29/20,\h5:00\hPM#iu', $node['date2']);
+        $this->assertMatchesRegularExpression('#5:00:00\hPM#iu', $node['date3']);
         $this->assertEquals('2020', $node['date4']);
         $this->assertEquals('This is a really long text field. It has a few sentences.', $node['myText']);
     }


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/12402341307/job/34623934194#step:12:115 where it seems that a utf space is used after a change in operating system, or operating system dependency that github actions uses

Solution copied from https://github.com/silverstripe/silverstripe-framework/pull/11409/files#diff-7ee4a8bc9e331e2692dc3e5b3c4827a84b8259878698ee68555490346af34ef7R51