### PR TITLE
DEP Don't include vendor-plugin as an explicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "php": "^8.3",
         "silverstripe/framework": "^6",
-        "silverstripe/vendor-plugin": "^2",
         "webonyx/graphql-php": "^15.19",
         "silverstripe/event-dispatcher": "^2",
         "guzzlehttp/guzzle": "^7.9",


### PR DESCRIPTION
We don't directly reference it in code or config, so we can rely on silverstripe/framework having this dependency for us.

## Issue
- https://github.com/silverstripe/.github/issues/311