### PR TITLE
DEP Require framework ^5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5.2",
+        "silverstripe/framework": "^5.3",
         "silverstripe/vendor-plugin": "^2",
         "webonyx/graphql-php": "^15.0.1",
         "silverstripe/event-dispatcher": "^1",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/357

Fixes issue where elemental 5.3.4 is being used because framework 5.2 is being used as installer 5.2 is the lowest version [compatible](https://github.com/silverstripe/gha-generate-matrix/blob/1/consts.php#L420) with graphql version in gha-generate-matrix causing CI to [fail](https://github.com/silverstripe/silverstripe-graphql/actions/runs/12761341352/job/35612312845)

Instead we need elemental [5.3.5](https://github.com/silverstripe/silverstripe-elemental/releases/tag/5.3.5) which requires framework 5.3

We need to use framework 5.3 in order to get this [fix](https://github.com/silverstripe/silverstripe-elemental/pull/1304)

