### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^8.3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "webonyx/graphql-php": "^15.19",
         "silverstripe/event-dispatcher": "^2",
         "guzzlehttp/guzzle": "^7.9",

--- a/docs/en/06_extending/adding_a_custom_operation.md
+++ b/docs/en/06_extending/adding_a_custom_operation.md
@@ -84,7 +84,7 @@ class DuplicateCreator implements OperationCreator
             if (!$dataClass) {
                 return null;
             }
-            return DataObject::get_by_id($dataClass, $args['id'])
+            return DataObject::get($dataClass)->setUseCache(true)->byID($args['id'])
                 ->duplicate();
         };
     }

--- a/src/Modules/Versioned/Resolvers/VersionFilters.php
+++ b/src/Modules/Versioned/Resolvers/VersionFilters.php
@@ -13,7 +13,7 @@ class VersionFilters
 {
     /**
      * Use this as a fallback where resolver results aren't queried as a DataList,
-     * but rather use DataObject::get_one(). Example: SiteTree::get_by_link().
+     * but rather use DataObject::get()->setUseCache(true). Example: SiteTree::get_by_link().
      * Note that the 'status' and 'version' modes are not supported.
      * Wrap this call in {@link Versioned::withVersionedMode()} in order to avoid side effects.
      *

--- a/src/Schema/DataObject/CreateCreator.php
+++ b/src/Schema/DataObject/CreateCreator.php
@@ -115,7 +115,7 @@ class CreateCreator implements OperationCreator, InputTypeProvider
 
             // Save and return
             $newObject->write();
-            $newObject = DataObject::get_by_id($dataClass, $newObject->ID);
+            $newObject = DataObject::get($dataClass)->setUseCache(true)->byID($newObject->ID);
 
             return $newObject;
         };


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
