### PR TITLE
ENH Optimise SQL queries to improve performance

### DIFF
--- a/src/Modules/AssetAdmin/FileFilter.php
+++ b/src/Modules/AssetAdmin/FileFilter.php
@@ -97,8 +97,8 @@ class FileFilter
 
         // Filter unknown id by known child if search is not applied
         if (!$search && isset($filter['anyChildId'])) {
-            $child = File::get()->byID($filter['anyChildId']);
-            $id = $child ? ($child->ParentID ?: 0) : 0;
+            $parentIDs = File::get()->filter('ID', $filter['anyChildId'])->limit(1)->column('ParentID');
+            $id = empty($parentIDs) ? 0 : $parentIDs[0];
             if ($id) {
                 $list = $list->filter('ID', $id);
             } else {

--- a/src/Modules/AssetAdmin/Resolvers/AssetAdminResolver.php
+++ b/src/Modules/AssetAdmin/Resolvers/AssetAdminResolver.php
@@ -33,8 +33,8 @@ class AssetAdminResolver
         $accessor = FieldAccessor::singleton();
         $parentID = isset($args['file']['parentId']) ? intval($args['file']['parentId']) : 0;
         if ($parentID) {
-            $parent = Versioned::get_by_stage(Folder::class, Versioned::DRAFT)->byID($parentID);
-            if (!$parent) {
+            $parentExists = Versioned::get_by_stage(Folder::class, Versioned::DRAFT)->filter('ID', $parentID)->exists();
+            if (!$parentExists) {
                 throw new InvalidArgumentException(sprintf(
                     '%s#%s not found',
                     Folder::class,
@@ -71,8 +71,8 @@ class AssetAdminResolver
         $accessor = FieldAccessor::singleton();
         $parentID = isset($args['folder']['parentId']) ? intval($args['folder']['parentId']) : 0;
         if ($parentID) {
-            $parent = Versioned::get_by_stage(Folder::class, Versioned::DRAFT)->byID($parentID);
-            if (!$parent) {
+            $parentExists = Versioned::get_by_stage(Folder::class, Versioned::DRAFT)->filter('ID', $parentID)->exists();
+            if (!$parentExists) {
                 throw new InvalidArgumentException(sprintf(
                     '%s#%s not found',
                     Folder::class,


### PR DESCRIPTION
While not reducing the _number_ of queries, I've updated a bunch of calls to `find()` and `byID()` (which were only being used to check if a record exists) to instead use `filter()->exists()` which is more efficient.

## Issue

- https://github.com/silverstripe/.github/issues/416