### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/ControllerTest.php
+++ b/tests/ControllerTest.php
@@ -158,8 +158,6 @@ class ControllerTest extends SapphireTest
     {
         $controller = new Controller(__FUNCTION__);
         $reflectionPrepareBacktrace = new ReflectionMethod($controller, 'prepareBacktrace');
-        $reflectionPrepareBacktrace->setAccessible(true);
-
         $this->assertSame($expected, $reflectionPrepareBacktrace->invoke($controller, $trace));
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.
