### PR TITLE
FIX AbstractTypeRegistry should be able to handle scalar types (fixes #646)

### DIFF
--- a/src/Schema/Storage/AbstractTypeRegistry.php
+++ b/src/Schema/Storage/AbstractTypeRegistry.php
@@ -8,6 +8,7 @@ use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Definition\NonNull;
 use GraphQL\Type\Definition\ListOfType;
 use Exception;
+use ReflectionMethod;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\GraphQL\Schema\SchemaBuilder;
 use SilverStripe\GraphQL\Schema\Exception\EmptySchemaException;
@@ -47,6 +48,13 @@ abstract class AbstractTypeRegistry
         try {
             return static::fromCache($typename);
         } catch (Exception $e) {
+            // Built-in scalars (with no schema-level override) will trigger exceptions as they don't have a
+            // generated file. So we have to catch that here and return the built-in types.
+            $builtIn = static::getBuiltinScalar($typename);
+            if ($builtIn && !static::hasRegistryScalarOverride($typename)) {
+                return $builtIn;
+            }
+
             if (!preg_match('/(Missing|Unknown) graphql/', $e->getMessage()) || !static::canRebuildOnMissing()) {
                 throw $e;
             }
@@ -137,6 +145,24 @@ abstract class AbstractTypeRegistry
             throw new Exception("Unknown graphql type: " . $typename);
         }
         return $type;
+    }
+
+    private static function getBuiltinScalar(string $typename): ?ScalarType
+    {
+        $builtIns = method_exists(Type::class, 'builtInScalars') ? Type::builtInScalars() : Type::getStandardTypes();
+        return $builtIns[$typename] ?? null;
+    }
+
+    private static function hasRegistryScalarOverride(string $typename): bool
+    {
+        if (!method_exists(static::class, $typename)) {
+            return false;
+        }
+
+        // Override exists only when concrete registry implementation declares Int()/String() etc itself.
+        // Inherited methods from this abstract class don't count
+        $method = new ReflectionMethod(static::class, $typename);
+        return $method->getDeclaringClass()->getName() === static::class;
     }
 
     public static function ID(): ScalarType

--- a/tests/Schema/AbstractTypeRegistryTest.php
+++ b/tests/Schema/AbstractTypeRegistryTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use ReflectionObject;
 use SilverStripe\Control\Session;
 use SilverStripe\GraphQL\Schema\Schema;
+use GraphQL\Type\Definition\ScalarType;
 
 class AbstractTypeRegistryTest extends SapphireTest
 {
@@ -164,6 +165,59 @@ class AbstractTypeRegistryTest extends SapphireTest
         $registry::get('test');
         // This test passes by not throwing any exceptions.
         $this->expectNotToPerformAssertions();
+    }
+
+    public function testGetReturnsBuiltinScalarWhenCacheMisses(): void
+    {
+        $registry = new class extends AbstractTypeRegistry
+        {
+            protected static function getSourceDirectory(): string
+            {
+                return AbstractTypeRegistryTest::SOURCE_DIRECTORY;
+            }
+
+            protected static function getSourceNamespace(): string
+            {
+                return '';
+            }
+
+            protected static function fromCache(string $typename): ScalarType
+            {
+                throw new Exception('Missing graphql file for ' . $typename);
+            }
+        };
+
+        $this->assertInstanceOf(ScalarType::class, $registry::get('Int'));
+    }
+
+    public function testGetDoesNotUseBuiltinWhenScalarOverrideExists(): void
+    {
+        $registry = new class extends AbstractTypeRegistry
+        {
+            protected static function getSourceDirectory(): string
+            {
+                return AbstractTypeRegistryTest::SOURCE_DIRECTORY;
+            }
+
+            protected static function getSourceNamespace(): string
+            {
+                return '';
+            }
+
+            protected static function fromCache(string $typename): ScalarType
+            {
+                throw new Exception('Missing graphql file for ' . $typename);
+            }
+
+            public static function Int(): ScalarType
+            {
+                throw new Exception('schema override should be used');
+            }
+        };
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Missing graphql file for Int');
+        $registry::get('Int');
     }
 
     /**


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
Updates `AbstractTypeRegistry` to support scalar types following [a change in `webonyx/graphql-php`](https://github.com/webonyx/graphql-php/commit/ef79ce18c14dd0d88bfc3a6c02a00f2adcbdf1bd)

## Manual testing steps
Run a dev/build with `webonyx/graphql-php: v15.31.0` or higher

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #646

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
